### PR TITLE
🐛 Logger configuration updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Ensure `updatePinoConfiguration` calls are included in the logger provided by the `LoggerModule` by loading the module asynchronously.
+
 ## v0.5.0 (2023-07-21)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
-        "@nestjs/common": "^10.1.0",
+        "@nestjs/common": "^10.1.2",
         "@nestjs/config": "^3.0.0",
-        "@nestjs/core": "^10.1.0",
+        "@nestjs/core": "^10.1.2",
         "@nestjs/passport": "^10.0.0",
-        "@nestjs/platform-express": "^10.1.0",
+        "@nestjs/platform-express": "^10.1.2",
         "@nestjs/swagger": "^7.1.2",
         "@nestjs/terminus": "^10.0.1",
         "class-transformer": "^0.5.1",
@@ -26,15 +26,15 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@nestjs/testing": "^10.1.0",
+        "@nestjs/testing": "^10.1.2",
         "@tsconfig/node18": "^18.2.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.3",
-        "@types/node": "^18.16.19",
+        "@types/node": "^18.17.1",
         "@types/passport-http-bearer": "^1.0.37",
         "@types/supertest": "^2.0.12",
         "@types/uuid": "^9.0.2",
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.2.0",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1324,12 +1324,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.1.0.tgz",
-      "integrity": "sha512-3GNOuDjeAqEVt5Zjia3ZSK55Jg80hIIkq52BOzU+LkCjFgbuEhDot80lCKu05WyntAMAq5wREoDRGEGlSVxENw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.1.2.tgz",
+      "integrity": "sha512-VS8xJtaYkUJHeQSnskZccPdlzd2A+j4aeFMTTmUJaUpTHsYBwUt1wWuZgyZeaSIIs0i0TcHla5rpFzRV3ZJmnQ==",
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.6.0",
+        "tslib": "2.6.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -1367,16 +1367,16 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-3ogHxrRAktQZNBSV709QxhNJQPsVInZRqxAK2fV7JDnfoBMu1lM3xI7cO498iViqq5xme3o/46+AdfjW9W2E2A==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-iOs29A/cgz8Ou8tOAeVPKYcfFoEiYbIwUvbg0UFI6VIiauo/zGalp/14ok1OL6PotrUU3mRkb0ZWYShINlvqIA==",
       "hasInstallScript": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
         "path-to-regexp": "3.2.0",
-        "tslib": "2.6.0",
+        "tslib": "2.6.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -1432,15 +1432,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.1.0.tgz",
-      "integrity": "sha512-wl3gsad9Zsv+Im8Fl+meXwpzPLNFRlLbrepGL6Y8za35xXsdx74oCv7NJbjptHMYdwzTZHvbyprfSxV+oHUaXg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.1.2.tgz",
+      "integrity": "sha512-cH2qiyoc3B5/tujh3rJPUcafc1tY12OJC3B01n5DzRTm4K8xELJbp+jEo3XpUQis2VyET21K7hYfwBU5RJlbaQ==",
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
         "express": "4.18.2",
         "multer": "1.4.4-lts.1",
-        "tslib": "2.6.0"
+        "tslib": "2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1552,12 +1552,12 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.1.0.tgz",
-      "integrity": "sha512-TqV/21PuU5GJ543oqLTrmQhWUiWwB7DDRcj5cknUdaOst+Kkwp0Sad3/5svcWgOB+QfFbwYlvIDeCkKJshZzPg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.1.2.tgz",
+      "integrity": "sha512-047SBcHxHNj/u/YEBTShaM3ijqjp+I8gbBy/sO18tGI0lHBdQztC6zLfIHddrF3rS2/fBLkES+/kemhkVlkpwQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "2.6.0"
+        "tslib": "2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1899,9 +1899,9 @@
       "dev": true
     },
     "node_modules/@types/koa": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
-      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.7.tgz",
+      "integrity": "sha512-Xd9xiGmTDv57y86kQYnBZZcE9H8cJhv+aL0YH+hZIa3rbUDNdk+EY6wcJC3xCyfrVIC+vjhtNENFwisF+E8Zhg==",
       "dev": true,
       "dependencies": {
         "@types/accepts": "*",
@@ -1930,9 +1930,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+      "version": "18.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.1.tgz",
+      "integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==",
       "dev": true
     },
     "node_modules/@types/passport": {
@@ -2052,16 +2052,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
+      "integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/type-utils": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/type-utils": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2088,16 +2088,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
+      "integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2117,13 +2117,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+      "integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0"
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2134,13 +2134,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
+      "integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2161,9 +2161,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+      "integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2174,13 +2174,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+      "integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2201,17 +2201,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+      "integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2226,12 +2226,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+      "integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3375,9 +3375,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.467",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.467.tgz",
-      "integrity": "sha512-2qI70O+rR4poYeF2grcuS/bCps5KJh6y1jtZMDDEteyKJQrzLOEhFyXCLcHW6DTBjKjWkk26JhWoAi+Ux9A0fg==",
+      "version": "1.4.471",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.471.tgz",
+      "integrity": "sha512-GpmGRC1vTl60w/k6YpQ18pSiqnmr0j3un//5TV1idPi6aheNfkT1Ye71tMEabWyNDO6sBMgAR+95Eb0eUUr1tA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3817,9 +3817,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4598,17 +4598,17 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -4626,9 +4626,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -4647,9 +4647,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
-      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
+      "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5372,27 +5372,18 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -7141,9 +7132,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "test:cov": "npm run test -- --coverage"
   },
   "dependencies": {
-    "@nestjs/common": "^10.1.0",
+    "@nestjs/common": "^10.1.2",
     "@nestjs/config": "^3.0.0",
-    "@nestjs/core": "^10.1.0",
+    "@nestjs/core": "^10.1.2",
     "@nestjs/passport": "^10.0.0",
-    "@nestjs/platform-express": "^10.1.0",
+    "@nestjs/platform-express": "^10.1.2",
     "@nestjs/swagger": "^7.1.2",
     "@nestjs/terminus": "^10.0.1",
     "class-transformer": "^0.5.1",
@@ -48,15 +48,15 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@nestjs/testing": "^10.1.0",
+    "@nestjs/testing": "^10.1.2",
     "@tsconfig/node18": "^18.2.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.16.19",
+    "@types/node": "^18.17.1",
     "@types/passport-http-bearer": "^1.0.37",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.2",
-    "@typescript-eslint/eslint-plugin": "^6.1.0",
+    "@typescript-eslint/eslint-plugin": "^6.2.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/src/nestjs/logging/logger.module.ts
+++ b/src/nestjs/logging/logger.module.ts
@@ -10,17 +10,20 @@ import { HEALTHCHECK_ENDPOINT } from '../healthcheck/index.js';
 @Global()
 @Module({
   imports: [
-    PinoLoggerModule.forRoot({
-      pinoHttp: {
-        // Passing the default logger ensures the default configuration is inherited...
-        logger: getDefaultLogger(),
-        // ... the following only sets up pino-http specific settings.
-        autoLogging: {
-          ignore: (req) =>
-            (req as any).originalUrl === `/${HEALTHCHECK_ENDPOINT}`,
+    // Using an async factory function ensures the logger had the chance to be configured before it is used.
+    PinoLoggerModule.forRootAsync({
+      useFactory: () => ({
+        pinoHttp: {
+          // Passing the default logger ensures the default configuration is inherited...
+          logger: getDefaultLogger(),
+          // ... the following only sets up pino-http specific settings.
+          autoLogging: {
+            ignore: (req) =>
+              (req as any).originalUrl === `/${HEALTHCHECK_ENDPOINT}`,
+          },
+          redact: { paths: ['req.headers.authorization'] },
         },
-        redact: { paths: ['req.headers.authorization'] },
-      },
+      }),
     }),
   ],
   providers: [Logger],


### PR DESCRIPTION
This PR fixes a bug where the `LoggerModule` would not expose the logger configuration updates because the default logger would be loaded too soon. It is fixed by loading the `LoggerModule` asynchronously, hence calling `getDefaultLogger()` later.

### Commits

- ⬆️ Upgrade Causa dependencies
- 🐛 Load the logger module asynchronously to include configuration updates
- 📝 Update changelog