### PR TITLE
✨ Logs prettifier testing utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Implement the `LoggerModule.forRoot()` function to accept an optional logger during initialization.
+- Add the `prettyLogs` option for the `makeTestAppFactory()` testing utility.
+
 Fixes:
 
 - Ensure `updatePinoConfiguration` calls are included in the logger provided by the `LoggerModule` by loading the module asynchronously.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "jest": "^29.6.1",
         "jest-extended": "^4.0.0",
         "passport-http-bearer": "^1.0.1",
+        "pino-pretty": "^10.2.0",
         "rimraf": "^5.0.1",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
@@ -2939,6 +2940,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3061,6 +3068,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -3403,6 +3419,15 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -3803,6 +3828,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4259,6 +4290,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/help-me/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/help-me/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/help-me/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/hexoid": {
@@ -5229,6 +5324,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6004,6 +6108,56 @@
         "process-warning": "^2.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+      "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
@@ -6186,6 +6340,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6528,6 +6692,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.5.4",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest": "^29.6.1",
     "jest-extended": "^4.0.0",
     "passport-http-bearer": "^1.0.1",
+    "pino-pretty": "^10.2.0",
     "rimraf": "^5.0.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",

--- a/src/nestjs/factory/testing.logger.spec.ts
+++ b/src/nestjs/factory/testing.logger.spec.ts
@@ -1,0 +1,71 @@
+import { jest } from '@jest/globals';
+import {
+  Controller,
+  INestApplication,
+  Injectable,
+  Module,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '../logging/index.js';
+import { createApp } from './app-factory.js';
+import { makeTestAppFactory } from './testing.js';
+
+@Injectable()
+class MyService {
+  constructor(private readonly logger: Logger) {}
+
+  computeStuff() {
+    this.logger.debug('👋');
+    return '➗';
+  }
+}
+
+@Controller('test')
+class TestController {
+  readonly configValue: string;
+  readonly serviceOutput: string;
+
+  constructor(configService: ConfigService, myService: MyService) {
+    this.configValue = configService.getOrThrow('MY_VAR');
+    this.serviceOutput = myService.computeStuff();
+  }
+}
+
+@Module({ controllers: [TestController], providers: [MyService] })
+class TestModule {}
+
+@Module({ imports: [TestModule] })
+class AppModule {}
+
+describe('testing', () => {
+  describe('makeTestAppFactory', () => {
+    // This test is in a separate file to ensure it runs independently of the other `createApp` calls.
+    // `PinoLogger` holds a singleton logger, which makes it hard to reset the logger configuration between test.
+    // The other solution would be to dynamically load the modules.
+    it('should pretty print logs', async () => {
+      jest.spyOn(process.stdout, 'write');
+
+      let app!: INestApplication;
+      try {
+        app = await createApp(AppModule, {
+          appFactory: makeTestAppFactory({
+            config: { MY_VAR: '🎉' },
+            prettyLogs: true,
+          }),
+        });
+      } finally {
+        await app?.close();
+      }
+
+      // This removes the color codes from the logs.
+      const actualStrings = (process.stdout.write as jest.Mock).mock.calls.map(
+        (args) => (args[0] as string).replaceAll(/\x1B\[[0-9;]*m/g, ''),
+      );
+      expect(
+        actualStrings.filter((log) =>
+          log.match(/^DEBUG \[\d\d:\d\d:\d\d\.\d\d\d\]: 👋\n$/),
+        ),
+      ).toHaveLength(1);
+    });
+  });
+});

--- a/src/nestjs/factory/testing.spec.ts
+++ b/src/nestjs/factory/testing.spec.ts
@@ -34,7 +34,7 @@ class TestModule {}
 })
 class AppModule {}
 
-describe('test-utils', () => {
+describe('testing', () => {
   describe('makeTestAppFactory', () => {
     it('should use the provided config dictionary', async () => {
       let app!: INestApplication;

--- a/src/nestjs/logging/logger.module.ts
+++ b/src/nestjs/logging/logger.module.ts
@@ -1,32 +1,65 @@
-import { Global, Logger, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module, ModuleMetadata } from '@nestjs/common';
 import { LoggerModule as PinoLoggerModule } from 'nestjs-pino';
+import { Logger } from 'pino';
 import { getDefaultLogger } from '../../logging/index.js';
 import { HEALTHCHECK_ENDPOINT } from '../healthcheck/index.js';
 
 /**
- * This module exposes a ready-to-use logger for NestJS REST services. It can be imported in the application module such
- * that the `Logger` dependency can be injected into any module.
+ * Options for the {@link LoggerModule}.
+ */
+type ModuleOptions = {
+  /**
+   * The pino logger to use.
+   * Defaults to `getDefaultLogger()`.
+   */
+  logger?: Logger;
+};
+
+/**
+ * Creates the definition for the {@link LoggerModule}, configuring pino HTTP in the process.
+ *
+ * @param options Options for the {@link LoggerModule}.
+ * @returns The {@link ModuleMetadata}.
+ */
+function createModuleMetadata(options: ModuleOptions = {}): ModuleMetadata {
+  return {
+    imports: [
+      // Using an async factory function ensures the logger had the chance to be configured before it is used.
+      PinoLoggerModule.forRootAsync({
+        useFactory: () => ({
+          pinoHttp: {
+            // Passing the default logger ensures the default configuration is inherited...
+            logger: options.logger ?? getDefaultLogger(),
+            // ... the following only sets up pino-http specific settings.
+            autoLogging: {
+              ignore: (req) =>
+                (req as any).originalUrl === `/${HEALTHCHECK_ENDPOINT}`,
+            },
+            redact: { paths: ['req.headers.authorization'] },
+          },
+        }),
+      }),
+    ],
+  };
+}
+
+/**
+ * This module exposes a ready-to-use logger for NestJS REST services in the form of the `PinoLogger`.
  */
 @Global()
-@Module({
-  imports: [
-    // Using an async factory function ensures the logger had the chance to be configured before it is used.
-    PinoLoggerModule.forRootAsync({
-      useFactory: () => ({
-        pinoHttp: {
-          // Passing the default logger ensures the default configuration is inherited...
-          logger: getDefaultLogger(),
-          // ... the following only sets up pino-http specific settings.
-          autoLogging: {
-            ignore: (req) =>
-              (req as any).originalUrl === `/${HEALTHCHECK_ENDPOINT}`,
-          },
-          redact: { paths: ['req.headers.authorization'] },
-        },
-      }),
-    }),
-  ],
-  providers: [Logger],
-  exports: [Logger],
-})
-export class LoggerModule {}
+@Module(createModuleMetadata())
+export class LoggerModule {
+  /**
+   * Creates a global {@link LoggerModule} that can be used by the entire application.
+   *
+   * @param options Options for the {@link LoggerModule}.
+   * @returns The logger module.
+   */
+  static forRoot(options: ModuleOptions = {}): DynamicModule {
+    return {
+      module: LoggerModule,
+      global: true,
+      ...createModuleMetadata(options),
+    };
+  }
+}


### PR DESCRIPTION
This PR adds the `prettyLogs` option to the `makeTestAppFactory` testing utility. When enabled, this prints text logs instead of JSON to the console, making them simpler to read.

### Commits

- ✨ Make the LoggerModule optionally accept a custom pino logger
- ➕ Depend on pino-pretty for development
- ✨ Implement the prettyLogs option for makeTestAppFactory
- 📝 Update changelog