### PR TITLE
🐛 Import from relative paths rather than the package

### DIFF
--- a/src/nestjs/openapi/api-error-description.decorator.ts
+++ b/src/nestjs/openapi/api-error-description.decorator.ts
@@ -1,5 +1,5 @@
-import { ErrorDto } from '@causa/runtime/nestjs';
 import { Type } from '@nestjs/common';
+import { ErrorDto } from '../errors/index.js';
 
 /**
  * The metadata key used to store the API error description.

--- a/src/nestjs/openapi/api-error-status-code.decorator.ts
+++ b/src/nestjs/openapi/api-error-status-code.decorator.ts
@@ -1,6 +1,6 @@
-import { ApiConstantProperty } from '@causa/runtime/nestjs';
 import { HttpStatus, Type } from '@nestjs/common';
 import { ErrorDto } from '../errors/index.js';
+import { ApiConstantProperty } from './api-constant-property.decorator.js';
 
 /**
  * The metadata key used to store the API error status code.


### PR DESCRIPTION
This fixes an error where imports should have come from relative paths in the package, rather than referencing the public package name.

### Commits

- 🐛 Import from relative paths rather than the package