### PR TITLE
🔖 Prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 (2023-10-23)
+
 Breaking changes:
 
 - Make the `updatedAt` version check optional in the `VersionedEntityManager`'s `update` and `delete` methods.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Make the `updatedAt` version check optional in the `VersionedEntityManager`'s `update` and `delete` methods.
- The entity ID (primary key) is now a separate argument of the `VersionedEntityManager.update` function.

Features:

- `VersionedEntityManager.update` can now accept a function to construct the update data.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.9.0