### PR TITLE
✨ `VersionedEntityManager` options improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Export `VersionedEntityOperationOptions` and `VersionedEntityUpdateOptions`.
+- Pass the current `transaction` to `VersionedEntityUpdateOptions.validationFn`.
+
 ## v0.9.0 (2023-10-23)
 
 Breaking changes:

--- a/src/versioned-entity/index.ts
+++ b/src/versioned-entity/index.ts
@@ -1,3 +1,7 @@
 export { VersionedEntityEventProcessor } from './event-processor.js';
-export { VersionedEntityManager } from './manager.js';
+export {
+  VersionedEntityManager,
+  VersionedEntityOperationOptions,
+  VersionedEntityUpdateOptions,
+} from './manager.js';
 export * from './versioned-entity.js';

--- a/src/versioned-entity/manager.spec.ts
+++ b/src/versioned-entity/manager.spec.ts
@@ -290,7 +290,10 @@ describe('VersionedEntityManager', () => {
       expect(mockEventTransaction.bufferedEvents).toEqual([
         { topic: 'my-topic', event: actualEvent, options: { attributes: {} } },
       ]);
-      expect(validationFn).toHaveBeenCalledExactlyOnceWith(existingEntity);
+      expect(validationFn).toHaveBeenCalledExactlyOnceWith(
+        existingEntity,
+        mockTransaction,
+      );
     });
 
     it('should use a function as the update', async () => {
@@ -525,7 +528,10 @@ describe('VersionedEntityManager', () => {
       expect(mockEventTransaction.bufferedEvents).toEqual([
         { topic: 'my-topic', event: actualEvent, options: { attributes: {} } },
       ]);
-      expect(validationFn).toHaveBeenCalledExactlyOnceWith(existingEntity);
+      expect(validationFn).toHaveBeenCalledExactlyOnceWith(
+        existingEntity,
+        mockTransaction,
+      );
     });
 
     it('should rethrow an error from the validation function', async () => {

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -26,22 +26,23 @@ import {
 /**
  * Options when performing a generic write operation on a versioned entity.
  */
-type VersionedEntityOperationOptions<T extends FindReplaceTransaction> = {
-  /**
-   * The transaction to use.
-   */
-  transaction?: T;
+export type VersionedEntityOperationOptions<T extends FindReplaceTransaction> =
+  {
+    /**
+     * The transaction to use.
+     */
+    transaction?: T;
 
-  /**
-   * Options when publishing the event.
-   */
-  publishOptions?: PublishOptions;
-};
+    /**
+     * Options when publishing the event.
+     */
+    publishOptions?: PublishOptions;
+  };
 
 /**
  * Options when performing an update operation on a versioned entity.
  */
-type VersionedEntityUpdateOptions<
+export type VersionedEntityUpdateOptions<
   T extends FindReplaceTransaction,
   P extends VersionedEntity,
 > = VersionedEntityOperationOptions<T> & {

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -51,8 +51,9 @@ export type VersionedEntityUpdateOptions<
    * This function should throw if the update should not be allowed.
    *
    * @param existingEntity The current state of the entity.
+   * @param transaction The current transaction.
    */
-  validationFn?: (existingEntity: P) => Promise<void>;
+  validationFn?: (existingEntity: P, transaction: T) => Promise<void>;
 
   /**
    * An existing entity to use instead of looking it up from the state.
@@ -182,7 +183,7 @@ export class VersionedEntityManager<
         }
 
         if (options.validationFn) {
-          await options.validationFn(existingEntity);
+          await options.validationFn(existingEntity, transaction);
         }
 
         if (


### PR DESCRIPTION
This PR exports the option types for the `VersionedEntityManager`, such that they can be reused by child classes. This also adds the current `transaction` as the second argument to `validationFn` options.

### Commits

- ✨ Export VersionedEntityOperationOptions and VersionedEntityUpdateOptions
- ✨ Pass the current transaction to VersionedEntityUpdateOptions.validationFn
- 📝 Update changelog