### PR TITLE
🔖 Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.10.0 (2023-10-23)
+
 Features:
 
 - Export `VersionedEntityOperationOptions` and `VersionedEntityUpdateOptions`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Export `VersionedEntityOperationOptions` and `VersionedEntityUpdateOptions`.
- Pass the current `transaction` to `VersionedEntityUpdateOptions.validationFn`.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.10.0