### PR TITLE
🔖 Prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0 (2023-11-27)
+
 Breaking changes:
 
 - Return the projection (or `null`) rather than a boolean in `VersionedEntityEventProcessor.processEvent`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Return the projection (or `null`) rather than a boolean in `VersionedEntityEventProcessor.processEvent`.

Features:

- Loosen the constraint on the `VersionedEntityEventProcessor` event type.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.12.0