### PR TITLE
🔖 Prepare v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.1 (2023-12-19)
+
 Fixes:
 
 - Validate inputs more thoroughly in `validateObject` and `parseObject`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Validate inputs more thoroughly in `validateObject` and `parseObject`.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.13.1