### PR TITLE
🔖 Prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.14.0 (2024-01-22)
+
 Breaking changes:
 
 - Provide OpenAPI 3.1.0 documentation for `Page` instead of 3.0.X.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Provide OpenAPI 3.1.0 documentation for `Page` instead of 3.0.X.

Features:

- Use `examples` rather than `example` in `@ApiConstantProperty` to provide OpenAPI 3.1.0 compatibility.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.14.0