### PR TITLE
🔖 Prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.15.0 (2024-02-08)
+
 Breaking changes:
 
 - Depend on `reflect-metadata` `0.2.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Depend on `reflect-metadata` `0.2.1`.
- Set the OpenAPI type as `integer` instead of `number` when relevant for constant types.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.15.0