### PR TITLE
🔖 Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.0 (2024-03-06)
+
 Breaking changes:
 
 - Change the `VersionedEntityEventProcessor` API, which now forces extending the class.


### PR DESCRIPTION
Breaking changes:

- Change the `VersionedEntityEventProcessor` API, which now forces extending the class.

Features:

- Optionally enable fetching the state before computing the projection in the `VersionedEntityEventProcessor`.

### Commits

- **📝 Update changelog**