### PR TITLE
🔖 Prepare v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.1 (2024-03-06)
+
 Fixes:
 
 - Export `VersionedEntityProjectionOptions`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Export `VersionedEntityProjectionOptions`.

### Commits

- **🔖 Set version to 0.16.1**
- **📝 Update changelog**