### PR TITLE
✨ Expose `NestApplicationOptions` in `createApp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Accept `NestApplicationOptions` in the `createApp` function. Custom `appFactory` should accept those options and forward them to the `NestFactory` call.
+
 ## v0.16.1 (2024-03-06)
 
 Fixes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@tsconfig/node18": "^18.2.2",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
-        "@types/node": "^18.19.21",
+        "@types/node": "^18.19.22",
         "@types/passport-http-bearer": "^1.0.41",
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^9.0.8",
@@ -46,7 +46,7 @@
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.2"
       },
       "engines": {
         "node": ">=16"
@@ -2132,9 +2132,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.21.tgz",
-      "integrity": "sha512-2Q2NeB6BmiTFQi4DHBzncSoq/cJMLDdhPaAoJFnFCyD9a8VPZRf7a1GAwp1Edb7ROaZc5Jz/tnZyL6EsWMRaqw==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2996,9 +2996,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001594",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
-      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+      "version": "1.0.30001596",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
+      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
       "dev": true,
       "funding": [
         {
@@ -3483,9 +3483,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.692",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.692.tgz",
-      "integrity": "sha512-d5rZRka9n2Y3MkWRN74IoAsxR0HK3yaAt7T50e3iT9VZmCCQDT3geXUO5ZRMhDToa1pkCeQXuNo+0g+NfDOVPA==",
+      "version": "1.4.695",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.695.tgz",
+      "integrity": "sha512-eMijZmeqPtm774pCZIOrfUHMs/7ls++W1sLhxwqgu8KQ8E2WmMtzwyqOMt0XXUJ3HTIPfuwlfwF+I5cwnfItBA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -7365,9 +7365,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tsconfig/node18": "^18.2.2",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
-    "@types/node": "^18.19.21",
+    "@types/node": "^18.19.22",
     "@types/passport-http-bearer": "^1.0.41",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^9.0.8",
@@ -68,6 +68,6 @@
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.2"
   }
 }

--- a/src/nestjs/factory/app-factory.spec.ts
+++ b/src/nestjs/factory/app-factory.spec.ts
@@ -67,7 +67,9 @@ describe('app-factory', () => {
     spyOnLogger();
     previousEnv = { ...process.env };
     process.env.SOME_CONF_VALUE = '🔧';
-    app = await createApp(AppModule);
+    app = await createApp(AppModule, {
+      nestApplicationOptions: { cors: true },
+    });
     request = supertest(app.getHttpServer());
   });
 
@@ -78,6 +80,7 @@ describe('app-factory', () => {
 
   it('should not return the x-powered-by header', async () => {
     const actualResponse = await request.get('/test').expect(200);
+
     expect(actualResponse.headers).not.toHaveProperty('x-powered-by');
   });
 
@@ -129,9 +132,18 @@ describe('app-factory', () => {
   });
 
   it('should transform the response', async () => {
-    return request
+    await request
       .post('/test')
       .send({ phoneNumber: '+33600000000' })
       .expect(201, { phoneNumber: '📞: +33600000000' });
+  });
+
+  it('should apply nest application options', async () => {
+    const actualResponse = await request.get('/test').expect(200);
+
+    expect(actualResponse.headers).toHaveProperty(
+      'access-control-allow-origin',
+      '*',
+    );
   });
 });

--- a/src/nestjs/factory/app-factory.ts
+++ b/src/nestjs/factory/app-factory.ts
@@ -3,6 +3,7 @@ import {
   INestApplication,
   Module,
   ModuleMetadata,
+  NestApplicationOptions,
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_INTERCEPTOR, NestFactory } from '@nestjs/core';
@@ -46,8 +47,12 @@ function createAppModule(businessModule: any): any {
 
 /**
  * A function that takes a NestJS module and returns a NestJS application.
+ * The passed options should be forwarded to the {@link NestFactory.create} call.
  */
-export type AppFactory = (module: any) => Promise<INestApplication>;
+export type AppFactory = (
+  module: any,
+  options?: NestApplicationOptions,
+) => Promise<INestApplication>;
 
 /**
  * Options for the {@link createApp} function.
@@ -58,14 +63,20 @@ export type CreateAppOptions = {
    * By default this uses `express`.
    */
   appFactory?: AppFactory;
+
+  /**
+   * Options to pass to the {@link CreateAppOptions.appFactory}, then forwarded to the {@link NestFactory.create} call.
+   */
+  nestApplicationOptions?: NestApplicationOptions;
 };
 
 /**
  * The default {@link AppFactory}, which uses `express`.
  */
-export const DEFAULT_APP_FACTORY: AppFactory = async (appModule) => {
+export const DEFAULT_APP_FACTORY: AppFactory = async (appModule, options) => {
   const app = await NestFactory.create<NestExpressApplication>(appModule, {
     bufferLogs: true,
+    ...options,
   });
 
   app.disable('x-powered-by');
@@ -90,7 +101,7 @@ export async function createApp(
 
   const AppModule = createAppModule(businessModule);
 
-  const app = await appFactory(AppModule);
+  const app = await appFactory(AppModule, options.nestApplicationOptions);
 
   const logger = app.get(Logger);
 


### PR DESCRIPTION
The title says it all. This allows the creator of the Nest.js application to pass the usual options, without having to override the application factory completely.

### Commits

- **⬆️ Upgrade dependencies**
- **✨ Accept Nest application options in createApp**
- **📝 Update changelog**