### PR TITLE
✨ Implement the `HealthCheckModule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
 
 - Rename `VersionedEntityEventProcessor` to `VersionedEventProcessor` and ease type constraints.
 
+Features:
+
+- Provide the `HealthCheckModule`, to ease the definition of health check endpoints.
+
 ## v0.17.0 (2024-03-07)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ Note that the `AuthModule` is not automatically added because it is only relevan
 
 `createApp` can also be used in combination with `makeTestAppFactory` from `@causa/runtime/nestjs/testing` through the `appFactory` option. This allows to override some of the modules (e.g. to mock services, use temporary resources, etc).
 
-#### Healthcheck
+#### Health check
 
-NestJS provides the [`@nestjs/terminus`](https://github.com/nestjs/terminus) package to implement health checks, and not much can be added generically on top. The implementation of the actual healthcheck may depend on the tech stack for example. However the `terminusModuleWithLogger` module provides Terminus properly configured with the pino logger.
+NestJS provides the [`@nestjs/terminus`](https://github.com/nestjs/terminus) package to implement health checks, and not much can be added generically on top. The implementation of the actual health check may depend on the tech stack for example. However the `terminusModuleWithLogger` module provides Terminus properly configured with the pino logger.
 
-When implementing a healthcheck route, it should be exposed under the `HEALTHCHECK_ENDPOINT`, such that only error responses are logged by pino.
+When implementing a health check route, it should be exposed under the `HEALTHCHECK_ENDPOINT`, such that only error responses are logged by pino.
+
+The `HealthCheckModule` can also be used to implement the health check route. In this case, only indicators, extending the `BaseHealthIndicatorService`, have to be implemented.
 
 #### Logging
 

--- a/src/nestjs/healthcheck/base-health-indicator.service.ts
+++ b/src/nestjs/healthcheck/base-health-indicator.service.ts
@@ -1,0 +1,15 @@
+import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+
+/**
+ * A base class that can be used to define a simple health check.
+ * This is meant to be used with the `HealthCheckModule`.
+ */
+export abstract class BaseHealthIndicatorService extends HealthIndicator {
+  /**
+   * Checks the health of the indicator.
+   * This should throw a `HealthCheckError` if the indicator is unhealthy.
+   *
+   * @returns The health indicator result.
+   */
+  abstract check(): Promise<HealthIndicatorResult>;
+}

--- a/src/nestjs/healthcheck/index.ts
+++ b/src/nestjs/healthcheck/index.ts
@@ -4,4 +4,6 @@
  */
 export const HEALTHCHECK_ENDPOINT = 'health';
 
+export { BaseHealthIndicatorService } from './base-health-indicator.service.js';
+export { HealthCheckModule } from './module.js';
 export * from './terminus.module.js';

--- a/src/nestjs/healthcheck/module.spec.ts
+++ b/src/nestjs/healthcheck/module.spec.ts
@@ -1,0 +1,83 @@
+import { INestApplication, Module } from '@nestjs/common';
+import { HealthCheckError, HealthIndicatorResult } from '@nestjs/terminus';
+import 'jest-extended';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent.js';
+import { getLoggedErrors, spyOnLogger } from '../../testing.js';
+import { AuthModule } from '../auth/index.js';
+import { createApp } from '../factory/index.js';
+import { LoggerModule } from '../logging/index.js';
+import { BaseHealthIndicatorService } from './base-health-indicator.service.js';
+import { HealthCheckModule } from './module.js';
+
+let isIndicator1Healthy = true;
+
+class Indicator1 extends BaseHealthIndicatorService {
+  async check(): Promise<HealthIndicatorResult> {
+    if (!isIndicator1Healthy) {
+      throw new HealthCheckError('Oopsie', this.getStatus('indicator1', false));
+    }
+
+    return this.getStatus('indicator1', true);
+  }
+}
+
+class Indicator2 extends BaseHealthIndicatorService {
+  async check(): Promise<HealthIndicatorResult> {
+    return this.getStatus('indicator2', true);
+  }
+}
+
+@Module({
+  imports: [
+    AuthModule, // Ensures the health endpoint is marked as public.
+    LoggerModule,
+    HealthCheckModule.forIndicators([Indicator1, Indicator2]),
+  ],
+})
+class MyModule {}
+
+describe('HealthcheckModule', () => {
+  let app: INestApplication;
+  let request: TestAgent<supertest.Test>;
+
+  beforeAll(async () => {
+    spyOnLogger();
+
+    app = await createApp(MyModule);
+    request = supertest(app.getHttpServer());
+  });
+
+  beforeEach(() => {
+    isIndicator1Healthy = true;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should expose the health endpoint', async () => {
+    await request.get('/health').expect(200);
+  });
+
+  it('should fail if one of the provided indicators fails', async () => {
+    isIndicator1Healthy = false;
+
+    await request.get('/health').expect(503);
+
+    expect(getLoggedErrors()).toEqual([
+      expect.objectContaining({
+        message: expect.toSatisfy((message: string) => {
+          expect(message).toContain('Health Check has failed!');
+          expect(message).toContain('"indicator1":{"status":"down"}');
+          expect(message).toContain('"indicator2":{"status":"up"}');
+          return true;
+        }),
+        req: expect.objectContaining({ url: '/health' }),
+        serviceContext: expect.objectContaining({
+          service: 'runtime',
+        }),
+      }),
+    ]);
+  });
+});

--- a/src/nestjs/healthcheck/module.ts
+++ b/src/nestjs/healthcheck/module.ts
@@ -1,0 +1,58 @@
+import { Controller, DynamicModule, Get, Module, Type } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import {
+  HealthCheckResult,
+  HealthCheckService,
+  HealthIndicatorFunction,
+} from '@nestjs/terminus';
+import { Public } from '../auth/index.js';
+import { BaseHealthIndicatorService } from './base-health-indicator.service.js';
+import { HEALTHCHECK_ENDPOINT } from './index.js';
+import { terminusModuleWithLogger } from './terminus.module.js';
+
+/**
+ * A module that provides a controller handling requests to the {@link HEALTHCHECK_ENDPOINT}.
+ */
+@Module({})
+export class HealthCheckModule {
+  /**
+   * Creates the health check module for the given indicator types.
+   * Indicators should extend the {@link BaseHealthIndicatorService}. They will be used as providers for this module,
+   * there is no need to export them from another module. However, their dependencies should be available in the rest of
+   * the application's modules.
+   *
+   * @param indicatorTypes The types of the health indicators to be used.
+   * @returns The module.
+   */
+  static forIndicators(
+    indicatorTypes: Type<BaseHealthIndicatorService>[],
+  ): DynamicModule {
+    @Controller(HEALTHCHECK_ENDPOINT)
+    class HealthcheckController {
+      private readonly indicatorFunctions: HealthIndicatorFunction[];
+
+      constructor(
+        private readonly health: HealthCheckService,
+        moduleRef: ModuleRef,
+      ) {
+        this.indicatorFunctions = indicatorTypes.map((indicatorType) => {
+          const indicator = moduleRef.get(indicatorType);
+          return () => indicator.check();
+        });
+      }
+
+      @Get()
+      @Public()
+      async healthCheck(): Promise<HealthCheckResult> {
+        return await this.health.check(this.indicatorFunctions);
+      }
+    }
+
+    return {
+      module: HealthCheckModule,
+      imports: [terminusModuleWithLogger],
+      controllers: [HealthcheckController],
+      providers: indicatorTypes,
+    };
+  }
+}

--- a/src/nestjs/healthcheck/terminus.module.spec.ts
+++ b/src/nestjs/healthcheck/terminus.module.spec.ts
@@ -29,7 +29,7 @@ class MyController {
 })
 class MyModule {}
 
-describe('terminsModuleWithLogger', () => {
+describe('terminusModuleWithLogger', () => {
   let app: INestApplication;
   let request: TestAgent<supertest.Test>;
 


### PR DESCRIPTION
This PR implements the `HealthCheckModule`, which provides a controller to easily define the `/health` endpoint in NestJS applications.
Users should only implement services extending the `BaseHealthIndicatorService` class, and list them when creating the `HealthCheckModule`.

### Commits

- **✨ Implement the HealthCheckModule**
- **📝 Document the HealthCheckModule**
- **📝 Update changelog**