### PR TITLE
🔖 Prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.0 (2024-03-19)
+
 Breaking changes:
 
 - Rename `VersionedEntityEventProcessor` to `VersionedEventProcessor` and ease type constraints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Rename `VersionedEntityEventProcessor` to `VersionedEventProcessor` and ease type constraints.

Features:

- Provide the `HealthCheckModule`, to ease the definition of health check endpoints.

### Commits

- **🔖 Set version to 0.18.0**
- **📝 Update changelog**