### PR TITLE
🔖 Prepare v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.1 (2024-03-22)
+
 Fixes:
 
 - Remove the health check endpoint exposed by the `HealthCheckModule` from OpenAPI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Remove the health check endpoint exposed by the `HealthCheckModule` from OpenAPI.

### Commits

- **🔖 Set version to 0.18.1**
- **📝 Update changelog**