### PR TITLE
💥 App factory breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Remove `json` parser override.
+- Treat `http-errors`-like errors as known in the `GlobalFilter`.
+- Add the application type to `CreateAppOptions`.
+
 Features:
 
 - Implement the `ProtobufjsObjectSerializer`.
+- Accept `extraConfiguration` in `CreateAppOptions`.
+
+Fixes:
+
+- `makeTestAppFactory` now returns a factory that supports `NestApplicationOptions`.
 
 ## v0.19.0 (2024-04-01)
 

--- a/src/nestjs/errors/exception-filter.module.spec.ts
+++ b/src/nestjs/errors/exception-filter.module.spec.ts
@@ -58,6 +58,11 @@ class TestController {
   async customError() {
     throw new MyError();
   }
+
+  @Get('/HttpErrors')
+  async httpErrors() {
+    throw { statusCode: 413, message: '🍔' };
+  }
 }
 
 describe('ExceptionFilterModule', () => {
@@ -78,63 +83,42 @@ describe('ExceptionFilterModule', () => {
   });
 
   it('should return 409 when an EntityAlreadyExistsError is thrown', async () => {
-    await request
-      .get('/VersionNotMatchingError')
-      .expect(409)
-      .expect(({ body }) => {
-        expect(body).toEqual({
-          statusCode: 409,
-          message:
-            'The provided version does not match the version of the resource on the server.',
-          errorCode: 'incorrectVersion',
-        });
-      });
+    await request.get('/VersionNotMatchingError').expect(409, {
+      statusCode: 409,
+      message:
+        'The provided version does not match the version of the resource on the server.',
+      errorCode: 'incorrectVersion',
+    });
 
     expect(getLoggedErrors()).toBeEmpty();
   });
 
   it('should return 409 when an EntityAlreadyExistsError is thrown', async () => {
-    await request
-      .get('/EntityAlreadyExistsError')
-      .expect(409)
-      .expect(({ body }) => {
-        expect(body).toEqual({
-          statusCode: 409,
-          message:
-            'The request conflicts with existing resource(s) on the server.',
-          errorCode: 'conflict',
-        });
-      });
+    await request.get('/EntityAlreadyExistsError').expect(409, {
+      statusCode: 409,
+      message: 'The request conflicts with existing resource(s) on the server.',
+      errorCode: 'conflict',
+    });
 
     expect(getLoggedErrors()).toBeEmpty();
   });
 
   it('should return 404 when an EntityNotFoundError is thrown', async () => {
-    await request
-      .get('/EntityNotFoundError')
-      .expect(404)
-      .expect(({ body }) => {
-        expect(body).toEqual({
-          statusCode: 404,
-          message: 'The requested resource was not found on the server.',
-          errorCode: 'notFound',
-        });
-      });
+    await request.get('/EntityNotFoundError').expect(404, {
+      statusCode: 404,
+      message: 'The requested resource was not found on the server.',
+      errorCode: 'notFound',
+    });
 
     expect(getLoggedErrors()).toBeEmpty();
   });
 
   it('should return 500 with the correct format', async () => {
-    await request
-      .get('/InternalServerError')
-      .expect(500)
-      .expect(({ body }) => {
-        expect(body).toEqual({
-          statusCode: 500,
-          message: 'An unexpected error occurred on the server.',
-          errorCode: 'internalServerError',
-        });
-      });
+    await request.get('/InternalServerError').expect(500, {
+      statusCode: 500,
+      message: 'An unexpected error occurred on the server.',
+      errorCode: 'internalServerError',
+    });
 
     expect(getLoggedErrors({ predicate: (o) => o.message === '💥' })).toEqual([
       expect.objectContaining({
@@ -148,16 +132,20 @@ describe('ExceptionFilterModule', () => {
   });
 
   it('should not convert a custom HTTP error to an InternalServerError', async () => {
-    await request
-      .get('/CustomError')
-      .expect(418)
-      .expect(({ body }) => {
-        expect(body).toEqual({
-          statusCode: 418,
-          message: '🫖',
-          errorCode: 'teapot',
-        });
-      });
+    await request.get('/CustomError').expect(418, {
+      statusCode: 418,
+      message: '🫖',
+      errorCode: 'teapot',
+    });
+
+    expect(getLoggedErrors()).toBeEmpty();
+  });
+
+  it('should handle http-errors', async () => {
+    await request.get('/HttpErrors').expect(413, {
+      statusCode: 413,
+      message: '🍔',
+    });
 
     expect(getLoggedErrors()).toBeEmpty();
   });

--- a/src/nestjs/factory/app-factory.spec.ts
+++ b/src/nestjs/factory/app-factory.spec.ts
@@ -7,6 +7,7 @@ import {
   Post,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { Transform } from 'class-transformer';
 import { IsPhoneNumber } from 'class-validator';
 import { PinoLogger } from 'nestjs-pino';
@@ -69,6 +70,8 @@ describe('app-factory', () => {
     process.env.SOME_CONF_VALUE = '🔧';
     app = await createApp(AppModule, {
       nestApplicationOptions: { cors: true },
+      extraConfiguration: (app: NestExpressApplication) =>
+        app.useBodyParser('json', { limit: 100 }),
     });
     request = supertest(app.getHttpServer());
   });
@@ -145,5 +148,12 @@ describe('app-factory', () => {
       'access-control-allow-origin',
       '*',
     );
+  });
+
+  it('should enforce extra configuration', async () => {
+    await request
+      .post('/test')
+      .send({ phoneNumber: '📱'.repeat(100) })
+      .expect(413);
   });
 });

--- a/src/nestjs/factory/app-factory.ts
+++ b/src/nestjs/factory/app-factory.ts
@@ -8,16 +8,10 @@ import {
 import { ConfigModule } from '@nestjs/config';
 import { APP_INTERCEPTOR, NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { json } from 'express';
 import { Logger } from 'nestjs-pino';
 import { ExceptionFilterModule } from '../errors/index.js';
 import { LoggerModule } from '../logging/index.js';
 import { ValidationModule } from '../validation/index.js';
-
-/**
- * The configuration for `body-parser` of the maximum size of input payloads when parsing JSON.
- */
-const DEFAULT_PAYLOAD_LIMIT = '5mb';
 
 /**
  * Creates the global module for a NestJS application.
@@ -80,7 +74,6 @@ export const DEFAULT_APP_FACTORY: AppFactory = async (appModule, options) => {
   });
 
   app.disable('x-powered-by');
-  app.use(json({ limit: DEFAULT_PAYLOAD_LIMIT }));
 
   return app;
 };

--- a/src/nestjs/factory/app-factory.ts
+++ b/src/nestjs/factory/app-factory.ts
@@ -43,31 +43,39 @@ function createAppModule(businessModule: any): any {
  * A function that takes a NestJS module and returns a NestJS application.
  * The passed options should be forwarded to the {@link NestFactory.create} call.
  */
-export type AppFactory = (
+export type AppFactory<T extends INestApplication = INestApplication> = (
   module: any,
   options?: NestApplicationOptions,
-) => Promise<INestApplication>;
+) => Promise<T>;
 
 /**
  * Options for the {@link createApp} function.
  */
-export type CreateAppOptions = {
+export type CreateAppOptions<T extends INestApplication = INestApplication> = {
   /**
    * The function to use to create an application.
    * By default this uses `express`.
    */
-  appFactory?: AppFactory;
+  appFactory?: AppFactory<T>;
 
   /**
    * Options to pass to the {@link CreateAppOptions.appFactory}, then forwarded to the {@link NestFactory.create} call.
    */
   nestApplicationOptions?: NestApplicationOptions;
+
+  /**
+   * A function that applies extra configuration to the Nest application.
+   */
+  extraConfiguration?: (app: T) => void;
 };
 
 /**
  * The default {@link AppFactory}, which uses `express`.
  */
-export const DEFAULT_APP_FACTORY: AppFactory = async (appModule, options) => {
+export const DEFAULT_APP_FACTORY: AppFactory<NestExpressApplication> = async (
+  appModule,
+  options,
+) => {
   const app = await NestFactory.create<NestExpressApplication>(appModule, {
     bufferLogs: true,
     ...options,
@@ -86,9 +94,9 @@ export const DEFAULT_APP_FACTORY: AppFactory = async (appModule, options) => {
  * @param options Options when creating the application.
  * @returns The {@link INestApplication}.
  */
-export async function createApp(
+export async function createApp<T extends INestApplication = INestApplication>(
   businessModule: any,
-  options: CreateAppOptions = {},
+  options: CreateAppOptions<T> = {},
 ): Promise<INestApplication> {
   const appFactory = options.appFactory ?? DEFAULT_APP_FACTORY;
 
@@ -96,8 +104,11 @@ export async function createApp(
 
   const app = await appFactory(AppModule, options.nestApplicationOptions);
 
-  const logger = app.get(Logger);
+  if (options.extraConfiguration) {
+    options.extraConfiguration(app as any);
+  }
 
+  const logger = app.get(Logger);
   app.useLogger(logger);
   app.enableShutdownHooks();
 

--- a/src/nestjs/factory/testing.ts
+++ b/src/nestjs/factory/testing.ts
@@ -120,7 +120,7 @@ export function makeTestAppFactory(
       : [options.overrides]
     : [];
 
-  return async (appModule) => {
+  return async (appModule, nestApplicationOptions) => {
     let builder = Test.createTestingModule({ imports: [appModule] })
       .overrideProvider(ConfigService)
       .useValue(configService);
@@ -137,6 +137,8 @@ export function makeTestAppFactory(
 
     const moduleRef = await builder.compile();
 
-    return moduleRef.createNestApplication<NestExpressApplication>();
+    return moduleRef.createNestApplication<NestExpressApplication>(
+      nestApplicationOptions,
+    );
   };
 }


### PR DESCRIPTION
This makes several fixes, improvements, and breaking changes to app factory-related feature. The most important breaking changes are:

- The limit for the JSON body parser is no longer modified. This should be configured by services using this library if needed.
- `http-errors`-like errors are caught and return the corresponding status code and message, instead of internal errors.

### Commits

- **🐛 Pass NestApplicationOptions in test factories**
- **💥 Remove JSON parser override**
- **✨ Filter errors from http-errors as known errors**
- **💥 Make CreateAppOptions generic and accept extraConfiguration**
- **📝 Update changelog**