### PR TITLE
✨ `CloudEventsEventHandlerInterceptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
 
 - Implement the `ProtobufjsObjectSerializer`.
 - Accept `extraConfiguration` in `CreateAppOptions`.
+- Implement the `CloudEventsEventHandlerInterceptor`.
 
 Fixes:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ As previously stated, this package does not provide any broker-specific implemen
 
 The `BaseEventHandlerInterceptor` class is a `NestInterceptor` that provides a base for an interceptor meant to be used with brokers pushing messages as HTTP requests (e.g. Pub/Sub with a [push subscription](https://cloud.google.com/pubsub/docs/push)).
 
+The `CloudEventsEventHandlerInterceptor` subclasses the `BaseEventHandlerInterceptor` to support CloudEvents events with HTTP binding.
+
 When the `@EventBody` decorator is used on a route's parameter, it indicates that this route responds to HTTP requests made by a message broker pushing events. An interceptor that inherits from `BaseEventHandlerInterceptor` catches those requests and parses the incoming events, ensuring the route handler receives a typed event, ready to be processed.
 
 #### Application factory

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^4.19.2",
         "nestjs-pino": "^4.0.0",
         "pino": "^9.0.0",
+        "raw-body": "^2.5.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express": "^4.19.2",
     "nestjs-pino": "^4.0.0",
     "pino": "^9.0.0",
+    "raw-body": "^2.5.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "uuid": "^9.0.1"

--- a/src/nestjs/events/cloudevents.interceptor.spec.ts
+++ b/src/nestjs/events/cloudevents.interceptor.spec.ts
@@ -1,0 +1,124 @@
+import {
+  Controller,
+  INestApplication,
+  Module,
+  NestApplicationOptions,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
+import { IsString } from 'class-validator';
+import 'jest-extended';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent.js';
+import { EventAttributes } from '../../events/index.js';
+import { JsonObjectSerializer } from '../../serialization/index.js';
+import { getLoggedErrors, getLoggedInfos, spyOnLogger } from '../../testing.js';
+import { createApp } from '../factory/index.js';
+import { Logger } from '../logging/index.js';
+import { CloudEventsEventHandlerInterceptor } from './cloudevents.interceptor.js';
+import { EventAttributes as EventAttributesDecorator } from './event-attributes.decorator.js';
+import { EventBody } from './event-body.decorator.js';
+
+class EventData {
+  @IsString()
+  readonly prop!: string;
+}
+
+@Controller()
+class MyController {
+  constructor(private readonly logger: Logger) {}
+
+  @Post()
+  @UseInterceptors(
+    CloudEventsEventHandlerInterceptor.withSerializer(
+      new JsonObjectSerializer(),
+    ),
+  )
+  async post(
+    @EventBody() data: EventData,
+    @EventAttributesDecorator() attributes: EventAttributes,
+  ): Promise<void> {
+    this.logger.info({ data, attributes }, '📫');
+  }
+}
+
+@Module({ controllers: [MyController] })
+class MyModule {}
+
+describe('CloudEventsEventHandlerInterceptor', () => {
+  let app: INestApplication;
+  let request: TestAgent<supertest.Test>;
+
+  beforeAll(async () => {
+    spyOnLogger();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  async function createAppAndRequest(
+    nestApplicationOptions?: NestApplicationOptions,
+  ): Promise<void> {
+    app = await createApp(MyModule, { nestApplicationOptions });
+    request = supertest(app.getHttpServer());
+  }
+
+  function expectReceivedEvent(data: EventData, attributes: EventAttributes) {
+    expect(getLoggedInfos({ predicate: (o) => o.message === '📫' })).toEqual([
+      expect.objectContaining({ data, attributes }),
+    ]);
+  }
+
+  function expectNoReceivedEvent() {
+    expect(
+      getLoggedInfos({ predicate: (o) => o.message === '📫' }),
+    ).toBeEmpty();
+  }
+
+  it('should parse the event data and attributes by reading the body', async () => {
+    await createAppAndRequest({ bodyParser: false });
+
+    await request
+      .post('/')
+      .set('ce-id', '123')
+      .set('ce-type', 'test')
+      .set('not-expected', '123')
+      .send({ prop: '💻' })
+      .expect(201);
+
+    expectReceivedEvent({ prop: '💻' }, { id: '123', type: 'test' });
+  });
+
+  it('should parse the event data and attributes by getting the rawBody of a consumed request', async () => {
+    await createAppAndRequest({ rawBody: true });
+
+    await request
+      .post('/')
+      .set('ce-id', '123')
+      .set('ce-type', 'test')
+      .send({ prop: '💻' })
+      .expect(201);
+
+    expectReceivedEvent({ prop: '💻' }, { id: '123', type: 'test' });
+  });
+
+  it('should log an error when the event body cannot be obtained', async () => {
+    await createAppAndRequest();
+
+    await request
+      .post('/')
+      .set('ce-id', '123')
+      .set('ce-type', 'test')
+      .send({ prop: '💻' })
+      .expect(201);
+
+    expectNoReceivedEvent();
+    expect(getLoggedErrors()).toEqual([
+      expect.objectContaining({
+        message: 'Received an invalid event.',
+        error: expect.stringContaining('Failed to get request body as buffer.'),
+      }),
+    ]);
+  });
+});

--- a/src/nestjs/events/cloudevents.interceptor.ts
+++ b/src/nestjs/events/cloudevents.interceptor.ts
@@ -1,0 +1,126 @@
+import {
+  ExecutionContext,
+  Injectable,
+  RawBodyRequest,
+  Type,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { PinoLogger } from 'nestjs-pino';
+import rawBody from 'raw-body';
+import { EventAttributes } from '../../events/index.js';
+import { ObjectSerializer } from '../../serialization/index.js';
+import {
+  BaseEventHandlerInterceptor,
+  ParsedEventRequest,
+} from './base.interceptor.js';
+
+/**
+ * The ID of the CloudEvents event handler interceptor, that can be passed to the `UseEventHandler` decorator.
+ */
+export const CLOUDEVENTS_EVENT_HANDLER_ID = 'cloudEvents';
+
+/**
+ * The prefix for CloudEvents headers in HTTP requests.
+ */
+const CLOUDEVENTS_HTTP_HEADER_PREFIX = 'ce-';
+
+/**
+ * The interceptor that should be added to controllers handling CloudEvents events.
+ * Request bodies are deserialized using the provided {@link ObjectSerializer}.
+ * CloudEvents attributes are parsed from `ce-*` headers and set as the event attributes.
+ * They can be retrieved using the `@EventAttributes` decorator.
+ */
+@Injectable()
+export class CloudEventsEventHandlerInterceptor extends BaseEventHandlerInterceptor {
+  /**
+   * Creates a new {@link CloudEventsEventHandlerInterceptor}.
+   * Do not use this constructor directly, use `CloudEventsEventHandlerInterceptor.withSerializer()` instead, either
+   * with `APP_INTERCEPTOR` or `UseInterceptors`.
+   *
+   * @param serializer The serializer to use to deserialize the event from the request body.
+   * @param reflector The {@link Reflector} to use.
+   * @param logger The {@link PinoLogger} to use.
+   */
+  constructor(
+    protected readonly serializer: ObjectSerializer,
+    reflector: Reflector,
+    logger: PinoLogger,
+  ) {
+    super(CLOUDEVENTS_EVENT_HANDLER_ID, reflector, logger);
+  }
+
+  /**
+   * Extracts CloudEvent attributes as {@link EventAttributes} from the request headers.
+   * Only headers starting with `ce-` are kept.
+   *
+   * @param request The request to parse the attributes from.
+   * @returns The {@link EventAttributes}.
+   */
+  private parseAttributes(request: Request): EventAttributes {
+    return Object.fromEntries(
+      Object.entries(request.headers).flatMap(([key, value]) => {
+        if (!key.startsWith(CLOUDEVENTS_HTTP_HEADER_PREFIX)) {
+          return [];
+        }
+
+        if (!(typeof value === 'string')) {
+          return [];
+        }
+
+        return [[key.slice(CLOUDEVENTS_HTTP_HEADER_PREFIX.length), value]];
+      }),
+    );
+  }
+
+  protected async parseEventFromContext(
+    context: ExecutionContext,
+    dataType: Type,
+  ): Promise<ParsedEventRequest> {
+    const request = context
+      .switchToHttp()
+      .getRequest<RawBodyRequest<Request>>();
+
+    const attributes = this.parseAttributes(request);
+    if (attributes.id) {
+      this.assignEventId(attributes.id);
+    }
+
+    return await this.wrapParsing(async () => {
+      let buffer: Buffer;
+      if (request.readable) {
+        buffer = await rawBody(request);
+      } else if (request.rawBody) {
+        buffer = request.rawBody;
+      } else {
+        throw new Error(
+          'Failed to get request body as buffer. Make sure that the body is not consumed before the interceptor, or to set `rawBody: true`.',
+        );
+      }
+
+      const body = await this.serializer.deserialize(dataType, buffer);
+
+      return { attributes, body };
+    });
+  }
+
+  /**
+   * Returns a `CloudEventsEventHandlerInterceptor` class that uses the provided {@link ObjectSerializer}.
+   * This can be used with the `UseInterceptors` decorator.
+   *
+   * @param serializer The {@link ObjectSerializer} to use to deserialize the event data.
+   * @returns A class that can be used as an interceptor for CloudEvents event handlers.
+   */
+  static withSerializer(
+    serializer: ObjectSerializer,
+  ): Type<CloudEventsEventHandlerInterceptor> {
+    @Injectable()
+    class CloudEventEventHandlerInterceptorWithSerializer extends CloudEventsEventHandlerInterceptor {
+      constructor(reflector: Reflector, logger: PinoLogger) {
+        super(serializer, reflector, logger);
+      }
+    }
+
+    return CloudEventEventHandlerInterceptorWithSerializer;
+  }
+}

--- a/src/nestjs/events/index.ts
+++ b/src/nestjs/events/index.ts
@@ -2,6 +2,10 @@ export {
   BaseEventHandlerInterceptor,
   ParsedEventRequest,
 } from './base.interceptor.js';
+export {
+  CLOUDEVENTS_EVENT_HANDLER_ID,
+  CloudEventsEventHandlerInterceptor,
+} from './cloudevents.interceptor.js';
 export * from './event-attributes.decorator.js';
 export * from './event-body.decorator.js';
 export * from './publisher.decorator.js';


### PR DESCRIPTION
This PR provides the `CloudEventsEventHandlerInterceptor` as a concrete subclass of `BaseEventHandlerInterceptor`. It handles CloudEvents events over HTTP (in binary mode).

### Commits

- **➕ Depend on raw-body**
- **✨ Implement the CloudEventsEventHandlerInterceptor**
- **📝 Update changelog**
- **📝 Document the CloudEventsEventHandlerInterceptor**