### PR TITLE
🔖 Prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.20.0 (2024-05-03)
+
 Breaking changes:
 
 - Remove `json` parser override.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Remove `json` parser override.
- Treat `http-errors`-like errors as known in the `GlobalFilter`.
- Add the application type to `CreateAppOptions`.

Features:

- Implement the `ProtobufjsObjectSerializer`.
- Accept `extraConfiguration` in `CreateAppOptions`.
- Implement the `CloudEventsEventHandlerInterceptor`.

Fixes:

- `makeTestAppFactory` now returns a factory that supports `NestApplicationOptions`.

### Commits

- **🔖 Set version to 0.20.0**
- **📝 Update changelog**