### PR TITLE
✨ Support for `redact` pino option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Breaking change:
 
 - Make `EventTransaction.publish` `options` optional.
 
+Features:
+
+- Support merging of the `redact.paths` `pino` option.
+- Move redaction of the `authorization` header to the base `pino` configuration.
+
 ## v0.20.0 (2024-05-03)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^4.19.2",
         "nestjs-pino": "^4.1.0",
         "pino": "^9.2.0",
+        "pino-http": "^10.2.0",
         "raw-body": "^2.5.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -5949,7 +5950,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.2.0.tgz",
       "integrity": "sha512-am03BxnV3Ckx68OkbH0iZs3indsrH78wncQ6w1w51KroIbvJZNImBKX2X1wjdY8lSyaJ0UrX/dnO2DY3cTeCRw==",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express": "^4.19.2",
     "nestjs-pino": "^4.1.0",
     "pino": "^9.2.0",
+    "pino-http": "^10.2.0",
     "raw-body": "^2.5.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/src/nestjs/logging/logger.module.ts
+++ b/src/nestjs/logging/logger.module.ts
@@ -35,7 +35,6 @@ function createModuleMetadata(options: ModuleOptions = {}): ModuleMetadata {
               ignore: (req) =>
                 (req as any).originalUrl === `/${HEALTHCHECK_ENDPOINT}`,
             },
-            redact: { paths: ['req.headers.authorization'] },
           },
         }),
       }),


### PR DESCRIPTION
This improves support for the `redact` pino option, such that redacted paths are merged when the pino configuration is updated.
The main use case is the redaction of additional request headers that may contain sensible data.

### Commits

- **➕ Depend on pino-http**
- **✨ Define redacted log paths in the configuration and support merging on updates**
- **🔥 Remove pure pino configuration from the NestJS LoggerModule**
- **📝 Update changelog**