### PR TITLE
🔖 Prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.21.0 (2024-07-04)
+
 Breaking change:
 
 - Make `EventTransaction.publish` `options` optional.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Make `EventTransaction.publish` `options` optional.

Features:

- Support merging of the `redact.paths` `pino` option.
- Move redaction of the `authorization` header to the base `pino` configuration.

### Commits

- **🔖 Set version to 0.21.0**
- **📝 Update changelog**