### PR TITLE
🔖 Prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.22.0 (2024-09-04)
+
 Breaking changes:
 
 - Convert uncaught `RetryableError`s to `ServiceUnavailableError`s in the global exception filter, and log them as warnings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Convert uncaught `RetryableError`s to `ServiceUnavailableError`s in the global exception filter, and log them as warnings.

Features:

- Uniformize logging by making the global exception filter log the stack in the `error` field.

### Commits

- **🔖 Set version to 0.22.0**
- **📝 Update changelog**