### PR TITLE
🔖 Prepare v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.23.0 (2024-11-14)
+
 Features:
 
 - Officially support Node.js 22.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Officially support Node.js 22.

Chores:

- Upgrade dependencies.

### Commits

- **🔖 Set version to 0.23.0**
- **📝 Update changelog**