### PR TITLE
🔖 Prepare v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.24.1 (2024-11-29)
+
 Fixes:
 
 - Ensure polling and publishing operations in the `OutboxEventSender` are over when the application shuts down.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^10.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Ensure polling and publishing operations in the `OutboxEventSender` are over when the application shuts down.

### Commits

- **🔖 Set version to 0.24.1**
- **📝 Update changelog**