### PR TITLE
💥 Fix `OutboxEventTransaction` reuse by passing a factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Pass a factory to `OutboxTransactionRunner.runStateTransaction`.
+
+Fixes:
+
+- Do not reuse `OutboxEventTransaction`s upon transaction retries.
+
 ## v0.24.2 (2024-12-03)
 
 Chores:

--- a/src/transaction/outbox/runner.ts
+++ b/src/transaction/outbox/runner.ts
@@ -37,11 +37,11 @@ export abstract class OutboxTransactionRunner<
    * Creates and runs the state transaction for the runner.
    * This should be implemented by subclasses, depending on the system used to store the state.
    *
-   * @param eventTransaction The {@link OutboxEventTransaction} to use when creating the {@link Transaction}.
+   * @param eventTransactionFactory The function to call to create a new {@link OutboxEventTransaction} on each attempt.
    * @param runFn The function to run in the transaction.
    */
   protected abstract runStateTransaction<RT>(
-    eventTransaction: OutboxEventTransaction,
+    eventTransactionFactory: () => OutboxEventTransaction,
     runFn: (transaction: T) => Promise<RT>,
   ): Promise<RT>;
 
@@ -77,10 +77,8 @@ export abstract class OutboxTransactionRunner<
   async run<RT>(runFn: (transaction: T) => Promise<RT>): Promise<[RT]> {
     this.logger.info('Starting a transaction.');
 
-    const eventTransaction = new OutboxEventTransaction(this.sender.publisher);
-
     const { result, events } = await this.runStateTransaction(
-      eventTransaction,
+      () => new OutboxEventTransaction(this.sender.publisher),
       async (transaction) => {
         this.logger.info('Starting transaction attempt.');
 


### PR DESCRIPTION
This fixes a serious bug where subsequent transaction attempts would reuse the same `OutboxEventTransaction`, and therefore publish events from previous attempts.

### Commits

- **💥 Fix OutboxEventTransaction reuse by passing a factory**
- **📝 Update changelog**