### PR TITLE
🔖 Prepare v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.27.0 (2025-02-06)
+
 Breaking changes:
 
 - The `LoggerModule` can no longer be used as a static module. `LoggerModule.forRoot()` must be used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^11.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": "github:causa-io/runtime-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- The `LoggerModule` can no longer be used as a static module. `LoggerModule.forRoot()` must be used.

Features:

- `bufferLogs` is passed to the factory used in `createApp`. This was already set for the default factory.

Fixes:

- `flushLogs()` is called after setting the logger on the application.

### Commits

- **🔖 Set version to 0.27.0**
- **📝 Update changelog**