### PR TITLE
💥 `TransactionRunner` refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Breaking changes:
 
 - Upgrade the minimum Node.js version to `20`.
 - Refactor the `Transaction` and `TransactionRunner`, making all transactions "find replace transactions", using the `get`, `set`, and `delete` terminology.
+- Define a unique `TransactionRunner.run` method which supports existing transactions (replacing `runInNewOrExisting`).
+
+Features:
+
+- Introduce the `ReadOnlyStateTransaction`, along with the corresponding `readOnly` option when creating a new transaction using a runner.
+- Support transaction-wide `publishOptions`.
 
 ## v0.27.2 (2025-05-28)
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The main purpose of `ObjectSerializer`s is to be used with an `EventPublisher` o
 
 ### (Event & state) transaction
 
-Event and state `Transaction`s are a core concept of Causa, which provide a way to modify the state of a system and publish related events as part of a single transaction. `Transaction`s are created by a `TransactionRunner`, which instantiates the underlying transaction(s) to a database and a message broker.
+Event and state `Transaction`s are a core concept of Causa, which provide a way to modify the state of a system and publish related events as part of a single transaction. `Transaction`s are created by a `TransactionRunner`, which instantiates the underlying transaction(s) to a database and a message broker. A `TransactionRunner` can also create a `ReadOnlyStateTransaction` if requested, which may avoid unnecessarily acquiring locks.
 
 `Transaction`s and `TransactionRunner`s are used by the `LockManager`, `VersionedEntityEventProcessor`, and the `VersionedEntityManager`.
 

--- a/src/lock/manager.spec.ts
+++ b/src/lock/manager.spec.ts
@@ -22,10 +22,12 @@ class MyLock implements LockEntity {
 }
 
 describe('LockManager', () => {
+  let runner: MockRunner;
   let manager: LockManager<MockTransaction, MyLock>;
 
   beforeAll(() => {
-    manager = new LockManager(MyLock, new MockRunner(), 1000);
+    runner = new MockRunner();
+    manager = new LockManager(MyLock, runner, 1000);
   });
 
   afterEach(() => {
@@ -167,12 +169,12 @@ describe('LockManager', () => {
     });
 
     it('should run in a transaction', async () => {
-      jest.spyOn(manager.runner, 'run');
+      jest.spyOn(runner, 'runReadWrite');
       const id = uuid.v4();
 
       await manager.acquire(id, { transaction: mockTransaction });
 
-      expect(manager.runner.run).not.toHaveBeenCalled();
+      expect(runner.runReadWrite).not.toHaveBeenCalled();
     });
   });
 
@@ -342,7 +344,7 @@ describe('LockManager', () => {
     });
 
     it('should run in a transaction', async () => {
-      jest.spyOn(manager.runner, 'run');
+      jest.spyOn(runner, 'runReadWrite');
       const id = uuid.v4();
       const lock = uuid.v4();
       const existingLock = new MyLock({
@@ -355,7 +357,7 @@ describe('LockManager', () => {
 
       await manager.release({ id, lock }, { transaction: mockTransaction });
 
-      expect(manager.runner.run).not.toHaveBeenCalled();
+      expect(runner.runReadWrite).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/transaction/event-transaction.ts
+++ b/src/transaction/event-transaction.ts
@@ -1,9 +1,20 @@
 import type { PublishOptions } from '../events/index.js';
 
 /**
+ * Options for publishing events as part of a transaction.
+ */
+export type TransactionPublishOptions = Pick<PublishOptions, 'attributes'>;
+
+/**
  * A transaction object used to represent events that should be published atomically.
  */
 export interface EventTransaction {
+  /**
+   * Base options for publishing events as part of the transaction.
+   * Attributes can be overridden when calling {@link EventTransaction.publish}.
+   */
+  readonly publishOptions: TransactionPublishOptions;
+
   /**
    * Adds the given event to the transaction.
    * It will be published if the transaction successfully commits.

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -2,5 +2,5 @@ export * from './errors.js';
 export * from './event-transaction.js';
 export * from './outbox/index.js';
 export * from './state-transaction.js';
-export { TransactionRunner } from './transaction-runner.js';
+export * from './transaction-runner.js';
 export { Transaction } from './transaction.js';

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -3,4 +3,4 @@ export * from './event-transaction.js';
 export * from './outbox/index.js';
 export * from './state-transaction.js';
 export * from './transaction-runner.js';
-export { Transaction } from './transaction.js';
+export * from './transaction.js';

--- a/src/transaction/outbox/event-transaction.spec.ts
+++ b/src/transaction/outbox/event-transaction.spec.ts
@@ -8,7 +8,12 @@ describe('OutboxEventTransaction', () => {
 
   beforeAll(() => {
     publisher = new MockPublisher();
-    transaction = new OutboxEventTransaction(publisher);
+  });
+
+  beforeEach(() => {
+    transaction = new OutboxEventTransaction(publisher, {
+      attributes: { att1: '🌱' },
+    });
   });
 
   describe('publish', () => {
@@ -21,7 +26,25 @@ describe('OutboxEventTransaction', () => {
         {
           topic: 'test-topic',
           data: Buffer.from(JSON.stringify(event)),
-          attributes: { prepared: '✅' },
+          attributes: { att1: '🌱', prepared: '✅' },
+          id: expect.any(String),
+        },
+      ]);
+      expect(uuid.version(transaction.events[0].id)).toBe(4);
+    });
+
+    it('should override transaction-wide attributes', async () => {
+      const event = { type: 'TestEvent' };
+
+      await transaction.publish('test-topic', event, {
+        attributes: { att1: '🍀', att2: '🌼' },
+      });
+
+      expect(transaction.events).toEqual([
+        {
+          topic: 'test-topic',
+          data: Buffer.from(JSON.stringify(event)),
+          attributes: { att1: '🍀', att2: '🌼', prepared: '✅' },
           id: expect.any(String),
         },
       ]);

--- a/src/transaction/outbox/event-transaction.ts
+++ b/src/transaction/outbox/event-transaction.ts
@@ -1,6 +1,9 @@
 import * as uuid from 'uuid';
 import type { EventPublisher, PublishOptions } from '../../events/index.js';
-import type { EventTransaction } from '../event-transaction.js';
+import type {
+  EventTransaction,
+  TransactionPublishOptions,
+} from '../event-transaction.js';
 import type { Transaction } from '../transaction.js';
 import type { OutboxEvent } from './event.js';
 
@@ -33,15 +36,23 @@ export class OutboxEventTransaction implements EventTransaction {
    * The passed {@link EventPublisher} will be used to prepare events for publishing, but not for actual publishing.
    *
    * @param publisher The {@link EventPublisher} to use to prepare events for publishing.
+   * @param publishOptions The {@link TransactionPublishOptions} to use when publishing events as part of the
+   *   transaction.
    */
-  constructor(private readonly publisher: EventPublisher) {}
+  constructor(
+    private readonly publisher: EventPublisher,
+    readonly publishOptions: TransactionPublishOptions = {},
+  ) {}
 
   async publish(
     topic: string,
     event: object,
     options: PublishOptions = {},
   ): Promise<void> {
-    const prepared = await this.publisher.prepare(topic, event, options);
+    const prepared = await this.publisher.prepare(topic, event, {
+      ...options,
+      attributes: { ...this.publishOptions.attributes, ...options.attributes },
+    });
 
     const staged: StagedOutboxEvent = {
       id: uuid.v4(),

--- a/src/transaction/state-transaction.ts
+++ b/src/transaction/state-transaction.ts
@@ -1,9 +1,27 @@
 import type { Type } from '@nestjs/common';
 
 /**
+ * A transaction that exposes methods to get entities based on their primary key.
+ */
+export interface ReadOnlyStateTransaction {
+  /**
+   * Looks up an entity of the given type with the same primary key as the given entity.
+   *
+   * @param type The type of the entity to find.
+   * @param entity The entity to use as a template for the search. All the primary key should be set, and other
+   *   properties will be ignored.
+   * @returns The entity if it exists, or `undefined` if it does not.
+   */
+  get<T extends object>(
+    type: Type<T>,
+    entity: Partial<T>,
+  ): Promise<T | undefined>;
+}
+
+/**
  * A transaction that exposes methods to get and set entities based on their primary key.
  */
-export interface StateTransaction {
+export interface StateTransaction extends ReadOnlyStateTransaction {
   /**
    * Replaces a possibly existing entity with the given one.
    * If the entity does not exist, it is created.
@@ -21,17 +39,4 @@ export interface StateTransaction {
    */
   delete<T extends object>(type: Type<T>, key: Partial<T>): Promise<void>;
   delete<T extends object>(entity: T): Promise<void>;
-
-  /**
-   * Looks up an entity of the given type with the same primary key as the given entity.
-   *
-   * @param type The type of the entity to find.
-   * @param entity The entity to use as a template for the search. All the primary key should be set, and other
-   *   properties will be ignored.
-   * @returns The entity if it exists, or `undefined` if it does not.
-   */
-  get<T extends object>(
-    type: Type<T>,
-    entity: Partial<T>,
-  ): Promise<T | undefined>;
 }

--- a/src/transaction/transaction-runner.spec.ts
+++ b/src/transaction/transaction-runner.spec.ts
@@ -1,16 +1,26 @@
 import { jest } from '@jest/globals';
 import 'jest-extended';
-import { TransactionRunner } from './transaction-runner.js';
+import {
+  TransactionRunner,
+  type ReadWriteTransactionOptions,
+  type TransactionFn,
+} from './transaction-runner.js';
 import { Transaction } from './transaction.js';
 import { MockTransaction } from './utils.test.js';
 
-const createdTransaction = new MockTransaction();
+const createdRWTransaction = new MockTransaction();
+const createdROTransaction = new MockTransaction();
 
-class MyRunner extends TransactionRunner<Transaction> {
-  async run<RT>(
-    runFn: (transaction: Transaction) => Promise<RT>,
-  ): Promise<[RT, ...any[]]> {
-    return [await runFn(createdTransaction), { someResult: '📈' }];
+class MyRunner extends TransactionRunner<Transaction, Transaction> {
+  async runReadWrite<RT>(
+    options: ReadWriteTransactionOptions,
+    runFn: TransactionFn<Transaction, RT>,
+  ): Promise<RT> {
+    return await runFn(createdRWTransaction);
+  }
+
+  async runReadOnly<RT>(runFn: TransactionFn<Transaction, RT>): Promise<RT> {
+    return await runFn(createdROTransaction);
   }
 }
 
@@ -19,29 +29,56 @@ describe('TransactionRunner', () => {
 
   beforeEach(() => {
     runner = new MyRunner();
-    jest.spyOn(runner, 'run');
+    jest.spyOn(runner, 'runReadWrite');
+    jest.spyOn(runner, 'runReadOnly');
   });
 
-  describe('runInNewOrExisting', () => {
+  describe('run', () => {
+    const fn = jest.fn(() => Promise.resolve('🎉'));
+
+    it('should run the given function in a new transaction', async () => {
+      const actualResult = await runner.run(fn);
+
+      expect(actualResult).toBe('🎉');
+      expect(fn).toHaveBeenCalledExactlyOnceWith(createdRWTransaction);
+      expect(runner.runReadWrite).toHaveBeenCalledExactlyOnceWith({}, fn);
+      expect(runner.runReadOnly).not.toHaveBeenCalled();
+    });
+
     it('should run the given function in the existing transaction', async () => {
       const transaction = new MockTransaction();
-      const fn = jest.fn(() => Promise.resolve('🎉'));
 
-      const actualResult = await runner.runInNewOrExisting(transaction, fn);
+      const actualResult = await runner.run({ transaction }, fn);
 
       expect(actualResult).toBe('🎉');
       expect(fn).toHaveBeenCalledExactlyOnceWith(transaction);
-      expect(runner.run).not.toHaveBeenCalled();
+      expect(runner.runReadWrite).not.toHaveBeenCalled();
+      expect(runner.runReadOnly).not.toHaveBeenCalled();
     });
 
-    it('should run the given function in a new transaction', async () => {
-      const fn = jest.fn(() => Promise.resolve('🎉'));
+    it('should run the given function in a new transaction with publish options', async () => {
+      const expectedOptions: ReadWriteTransactionOptions = {
+        publishOptions: { attributes: { tada: '🎉' } },
+      };
 
-      const actualResult = await runner.runInNewOrExisting(undefined, fn);
+      const actualResult = await runner.run(expectedOptions, fn);
 
       expect(actualResult).toBe('🎉');
-      expect(fn).toHaveBeenCalledExactlyOnceWith(createdTransaction);
-      expect(runner.run).toHaveBeenCalledExactlyOnceWith(fn);
+      expect(fn).toHaveBeenCalledExactlyOnceWith(createdRWTransaction);
+      expect(runner.runReadWrite).toHaveBeenCalledExactlyOnceWith(
+        expectedOptions,
+        fn,
+      );
+      expect(runner.runReadOnly).not.toHaveBeenCalled();
+    });
+
+    it('should run the given function in a read-only transaction', async () => {
+      const actualResult = await runner.run({ readOnly: true }, fn);
+
+      expect(actualResult).toBe('🎉');
+      expect(fn).toHaveBeenCalledExactlyOnceWith(createdROTransaction);
+      expect(runner.runReadWrite).not.toHaveBeenCalled();
+      expect(runner.runReadOnly).toHaveBeenCalledExactlyOnceWith(fn);
     });
   });
 });

--- a/src/transaction/transaction-runner.ts
+++ b/src/transaction/transaction-runner.ts
@@ -1,39 +1,149 @@
+import type { PublishOptions } from '../events/publisher.js';
+import type { ReadOnlyStateTransaction } from './state-transaction.js';
 import { Transaction } from './transaction.js';
+
+/**
+ * Option for a function that accepts a {@link Transaction}.
+ */
+export type TransactionOption<T extends Transaction> = {
+  /**
+   * An existing transaction to run the function in.
+   * If provided, the function will be run in this transaction instead of creating a new one.
+   */
+  transaction?: T;
+};
+
+/**
+ * Options for a function that accepts a {@link ReadOnlyStateTransaction}.
+ */
+export type ReadOnlyTransactionOption<ROT extends ReadOnlyStateTransaction> = {
+  /**
+   * An existing transaction to run the function in.
+   * If provided, the function will be run in this transaction instead of creating a new one.
+   */
+  transaction?: ROT;
+};
+
+/**
+ * Options when creating a new read-write transaction.
+ */
+export type ReadWriteTransactionOptions = {
+  /**
+   * {@link PublishOptions} applying to all events published within the transaction.
+   */
+  publishOptions?: Pick<PublishOptions, 'attributes'>;
+};
+
+/**
+ * Options for the {@link TransactionRunner.run} method.
+ * This is only defined for internal use, as the `run` method is overloaded to accept different types of options.
+ */
+type RunOptions<
+  RWT extends Transaction,
+  ROT extends ReadOnlyStateTransaction,
+> =
+  | TransactionOption<RWT>
+  | ReadWriteTransactionOptions
+  | (ReadOnlyTransactionOption<ROT> & { readOnly: true });
+
+/**
+ * A function to run within a transaction.
+ */
+export type TransactionFn<
+  T extends Transaction | ReadOnlyStateTransaction,
+  RT,
+> = (transaction: T) => Promise<RT>;
 
 /**
  * The abstract base class for transaction runners.
  * Transaction runners are responsible for creating and committing {@link Transaction}s, while the actual processing
  * occurring within the transaction is handled by the passed asynchronous function.
  */
-export abstract class TransactionRunner<T extends Transaction> {
+export abstract class TransactionRunner<
+  RWT extends Transaction,
+  ROT extends ReadOnlyStateTransaction,
+> {
+  /**
+   * Runs the given function in a newly-created read-write transaction.
+   * This method should be implemented by subclasses to create the transaction and run the function within it.
+   *
+   * @param options Options for the transaction.
+   * @param runFn The function to run in the transaction.
+   * @returns The return value of the `runFn` function.
+   */
+  protected abstract runReadWrite<RT>(
+    options: ReadWriteTransactionOptions,
+    runFn: TransactionFn<RWT, RT>,
+  ): Promise<RT>;
+
+  /**
+   * Runs the given function in a newly-created read-only transaction.
+   * This method should be implemented by subclasses to create the transaction and run the function within it.
+   *
+   * @param runFn The function to run in the read-only transaction.
+   * @returns The return value of the `runFn` function.
+   */
+  protected abstract runReadOnly<RT>(
+    runFn: TransactionFn<ROT, RT>,
+  ): Promise<RT>;
+
   /**
    * Runs the given function in a newly-created transaction.
    *
    * @param runFn The function to run in the transaction.
-   * @returns The return value of the `runFn` function, as well as possible implementation-specific transaction results.
+   * @returns The return value of the `runFn` function.
    */
-  abstract run<RT>(
-    runFn: (transaction: T) => Promise<RT>,
-  ): Promise<[RT, ...any]>;
+  run<RT>(runFn: TransactionFn<RWT, RT>): Promise<RT>;
 
   /**
-   * Runs the given function in the given transaction, or in a newly-created transaction if the given transaction is
-   * `undefined`.
+   * Runs the given function in a new or existing transaction, depending on the provided options.
    *
-   * @param transaction The {@link Transaction} to run the function in. If `undefined`, a new transaction will be
-   *   created and committed.
+   * @param options Options for running the transaction, which may include an existing transaction or publish options.
    * @param runFn The function to run in the transaction.
    * @returns The return value of the `runFn` function.
    */
-  async runInNewOrExisting<RT>(
-    transaction: T | undefined,
-    runFn: (transaction: T) => Promise<RT>,
+  run<RT>(
+    options: TransactionOption<RWT> | ReadWriteTransactionOptions,
+    runFn: TransactionFn<RWT, RT>,
+  ): Promise<RT>;
+
+  /**
+   * Runs the given function in a read-only transaction.
+   *
+   * @param options Options for running a read-only transaction, which may include an existing transaction.
+   * @param runFn The function to run in the read-only transaction.
+   * @returns The return value of the `runFn` function.
+   */
+  run<RT>(
+    options: ReadOnlyTransactionOption<ROT> & {
+      /**
+       * Whether the transaction to run is read-only.
+       */
+      readOnly: true;
+    },
+    runFn: TransactionFn<ROT, RT>,
+  ): Promise<RT>;
+
+  async run<RT>(
+    optionsOrRunFn: RunOptions<RWT, ROT> | TransactionFn<RWT, RT>,
+    runFn?: TransactionFn<RWT, RT> | TransactionFn<ROT, RT>,
   ): Promise<RT> {
-    if (transaction) {
-      return runFn(transaction);
+    const options: RunOptions<RWT, ROT> = runFn
+      ? (optionsOrRunFn as RunOptions<RWT, ROT>)
+      : {};
+    runFn ??= optionsOrRunFn as TransactionFn<RWT, RT> | TransactionFn<ROT, RT>;
+
+    if ('transaction' in options && options.transaction) {
+      return await runFn(options.transaction as any);
     }
 
-    const [returnValue] = await this.run(runFn);
-    return returnValue;
+    if ('readOnly' in options) {
+      return await this.runReadOnly(runFn as TransactionFn<ROT, RT>);
+    }
+
+    return await this.runReadWrite(
+      options as ReadWriteTransactionOptions,
+      runFn as TransactionFn<RWT, RT>,
+    );
   }
 }

--- a/src/transaction/transaction-runner.ts
+++ b/src/transaction/transaction-runner.ts
@@ -1,4 +1,4 @@
-import type { PublishOptions } from '../events/publisher.js';
+import type { TransactionPublishOptions } from './event-transaction.js';
 import type { ReadOnlyStateTransaction } from './state-transaction.js';
 import { Transaction } from './transaction.js';
 
@@ -29,9 +29,9 @@ export type ReadOnlyTransactionOption<ROT extends ReadOnlyStateTransaction> = {
  */
 export type ReadWriteTransactionOptions = {
   /**
-   * {@link PublishOptions} applying to all events published within the transaction.
+   * Publish options applying to all events published within the transaction.
    */
-  publishOptions?: Pick<PublishOptions, 'attributes'>;
+  publishOptions?: TransactionPublishOptions;
 };
 
 /**

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -1,7 +1,10 @@
 import type { Type } from '@nestjs/common';
 import type { PublishOptions } from '../events/index.js';
 import { TransactionOldTimestampError } from './errors.js';
-import type { EventTransaction } from './event-transaction.js';
+import type {
+  EventTransaction,
+  TransactionPublishOptions,
+} from './event-transaction.js';
 import type { StateTransaction } from './state-transaction.js';
 
 /**
@@ -12,6 +15,14 @@ import type { StateTransaction } from './state-transaction.js';
 export abstract class Transaction
   implements StateTransaction, EventTransaction
 {
+  /**
+   * Creates a new {@link Transaction}.
+   *
+   * @param publishOptions The {@link TransactionPublishOptions} to use when publishing events as part of the
+   *   transaction.
+   */
+  constructor(readonly publishOptions: TransactionPublishOptions) {}
+
   /**
    * The timestamp for the transaction, used as the single point in time at which the state changes and events will be
    * considered to have occurred.

--- a/src/transaction/utils.test.ts
+++ b/src/transaction/utils.test.ts
@@ -10,6 +10,7 @@ import {
   type OutboxTransaction,
   type StateTransaction,
   Transaction,
+  type TransactionPublishOptions,
   TransactionRunner,
 } from './index.js';
 import type {
@@ -38,6 +39,10 @@ export class MockPublisher implements EventPublisher {
 export class MockTransaction extends Transaction implements OutboxTransaction {
   entities: Record<string, any> = {};
   eventTransaction = new OutboxEventTransaction(new MockPublisher());
+
+  constructor(publishOptions: TransactionPublishOptions = {}) {
+    super(publishOptions);
+  }
 
   clear() {
     this.entities = {};

--- a/src/transaction/utils.test.ts
+++ b/src/transaction/utils.test.ts
@@ -12,6 +12,10 @@ import {
   Transaction,
   TransactionRunner,
 } from './index.js';
+import type {
+  ReadWriteTransactionOptions,
+  TransactionFn,
+} from './transaction-runner.js';
 
 export class MockPublisher implements EventPublisher {
   async flush(): Promise<void> {}
@@ -77,10 +81,20 @@ export const mockTransaction: MockTransaction & {
   get: jest.SpiedFunction<StateTransaction['get']>;
 } = new MockTransaction() as any;
 
-export class MockRunner extends TransactionRunner<MockTransaction> {
-  async run<RT>(
-    runFn: (transaction: MockTransaction) => Promise<RT>,
-  ): Promise<[RT]> {
-    return [await runFn(mockTransaction)];
+export class MockRunner extends TransactionRunner<
+  MockTransaction,
+  MockTransaction
+> {
+  public async runReadWrite<RT>(
+    options: ReadWriteTransactionOptions,
+    runFn: TransactionFn<MockTransaction, RT>,
+  ): Promise<RT> {
+    return await runFn(mockTransaction);
+  }
+
+  public async runReadOnly<RT>(
+    runFn: TransactionFn<MockTransaction, RT>,
+  ): Promise<RT> {
+    return await runFn(mockTransaction);
   }
 }

--- a/src/versioned-entity/event-processor.spec.ts
+++ b/src/versioned-entity/event-processor.spec.ts
@@ -60,6 +60,7 @@ const projectionFn = jest.fn(
 
 export class MyProcessor extends VersionedEventProcessor<
   MockTransaction,
+  MockTransaction,
   MyEvent,
   MyEntity
 > {

--- a/src/versioned-entity/manager.spec.ts
+++ b/src/versioned-entity/manager.spec.ts
@@ -84,10 +84,15 @@ class MySimpleEvent implements Event<string, MySimpleEntity> {
 }
 
 describe('VersionedEntityManager', () => {
-  let manager: VersionedEntityManager<Transaction, MyEvent>;
+  let manager: VersionedEntityManager<
+    Transaction,
+    Transaction,
+    MyEvent,
+    MockRunner
+  >;
 
   beforeEach(() => {
-    manager = new VersionedEntityManager<Transaction, MyEvent>(
+    manager = new VersionedEntityManager(
       'my-topic',
       MyEvent,
       MyEntity,
@@ -203,7 +208,7 @@ describe('VersionedEntityManager', () => {
     });
 
     it('should accept options', async () => {
-      jest.spyOn(manager.runner, 'run');
+      jest.spyOn(manager.runner, 'runReadWrite');
 
       const actualEvent = await manager.create(
         'myEntityCreated',
@@ -217,7 +222,7 @@ describe('VersionedEntityManager', () => {
         },
       );
 
-      expect(manager.runner.run).not.toHaveBeenCalled();
+      expect(manager.runner.runReadWrite).not.toHaveBeenCalled();
       expectPublishedEvent(actualEvent, { att1: '🎁' });
     });
   });
@@ -395,7 +400,7 @@ describe('VersionedEntityManager', () => {
     });
 
     it('should accept options', async () => {
-      jest.spyOn(manager.runner, 'run');
+      jest.spyOn(manager.runner, 'runReadWrite');
       const existingEntity = new MyEntity({ id: 'abc' });
       // The existing entity is not set in the transaction entities, and `update` should only use the provided option.
 
@@ -410,12 +415,17 @@ describe('VersionedEntityManager', () => {
         },
       );
 
-      expect(manager.runner.run).not.toHaveBeenCalled();
+      expect(manager.runner.runReadWrite).not.toHaveBeenCalled();
       expectPublishedEvent(actualEvent, { att1: '🎁' });
     });
 
     it('should use the provided custom update logic', async () => {
-      class MyManager extends VersionedEntityManager<Transaction, MyEvent> {
+      class MyManager extends VersionedEntityManager<
+        Transaction,
+        Transaction,
+        MyEvent,
+        MockRunner
+      > {
         protected makeUpdatedObject(
           existingEntity: MyEntity,
           update: Partial<MyEntity>,
@@ -560,7 +570,7 @@ describe('VersionedEntityManager', () => {
     });
 
     it('should accept options', async () => {
-      jest.spyOn(manager.runner, 'run');
+      jest.spyOn(manager.runner, 'runReadWrite');
       const existingEntity = new MyEntity({ id: 'abc' });
       // The existing entity is not set in the transaction entities, and `delete` should only use the provided option.
 
@@ -574,16 +584,20 @@ describe('VersionedEntityManager', () => {
         },
       );
 
-      expect(manager.runner.run).not.toHaveBeenCalled();
+      expect(manager.runner.runReadWrite).not.toHaveBeenCalled();
       expectPublishedEvent(actualEvent, { att1: '🎁' });
     });
   });
 
   describe('without creation and deletion timestamps', () => {
-    let manager: VersionedEntityManager<Transaction, MySimpleEvent>;
+    let manager: VersionedEntityManager<
+      Transaction,
+      Transaction,
+      MySimpleEvent
+    >;
 
     beforeEach(() => {
-      manager = new VersionedEntityManager<Transaction, MySimpleEvent>(
+      manager = new VersionedEntityManager(
         'my-topic',
         MySimpleEvent,
         MySimpleEntity,


### PR DESCRIPTION
### 📝 Description of the PR

Following #112, this brings other breaking changes and improvements to the `TransactionRunner`, e.g. by providing a unique `run` method, supporting read-only transactions, and supporting transaction-wide publish options.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.