### PR TITLE
💥 Versioned entities breaking changes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ Breaking changes:
 - Upgrade the minimum Node.js version to `20`.
 - Refactor the `Transaction` and `TransactionRunner`, making all transactions "find replace transactions", using the `get`, `set`, and `delete` terminology.
 - Define a unique `TransactionRunner.run` method which supports existing transactions (replacing `runInNewOrExisting`).
+- Replace `skipVersionCheck` option with `existingState` in the `VersionedEventProcessor`.
+- Make `VersionedEventProcessor.processEvent` throw instead of returning `null`, and introduce the `processOrSkipEvent` method with the old behavior.
+- Allow `VersionedEventProcessor.project` to return a context, which can be used to specify a version property to use, replaces the `stateKeyForEvent` logic, and to support merges of partial projections.
 
 Features:
 
 - Introduce the `ReadOnlyStateTransaction`, along with the corresponding `readOnly` option when creating a new transaction using a runner.
 - Support transaction-wide `publishOptions`.
+- Implement `VersionedEventProcessor` and `VersionedEntityManager` `get` method.
+- Support `reprocessEqualVersion` in the `VersionedEventProcessor` when processing events for backfilling use cases.
+
+Fixes:
+
+- Do not check `deletedAt` when the entity does not have a deletion property.
 
 ## v0.27.2 (2025-05-28)
 

--- a/src/errors/entity.ts
+++ b/src/errors/entity.ts
@@ -78,6 +78,32 @@ export class IncorrectEntityVersionError extends EntityError {
 }
 
 /**
+ * An error thrown when trying to process an entity that has an older version than the one in the state.
+ */
+export class OldEntityVersionError extends EntityError {
+  /**
+   * Creates a new {@link OldEntityVersionError}.
+   *
+   * @param entityType The type of entity, or `null` if it is not available.
+   * @param key A value representing the key used to look up the entity, or `null` if it is not available.
+   * @param processedVersion The version of the entity being processed.
+   * @param stateVersion The version of the entity, as found in the state.
+   */
+  constructor(
+    entityType: EntityTypeForError,
+    key: any,
+    readonly processedVersion: Date,
+    readonly stateVersion: Date,
+  ) {
+    super(
+      entityType,
+      key,
+      'The processed entity version is older than the existing one.',
+    );
+  }
+}
+
+/**
  * An error thrown when trying to perform an operation on an entity that is not supported.
  */
 export class UnsupportedEntityOperationError extends EntityError {}

--- a/src/versioned-entity/event-processor.ts
+++ b/src/versioned-entity/event-processor.ts
@@ -200,4 +200,29 @@ export abstract class VersionedEventProcessor<
       },
     );
   }
+
+  /**
+   * Processes the given event, building the corresponding state.
+   * This is similar to {@link VersionedEventProcessor.processEvent}, but it returns `null` if the event was skipped
+   * because a more recent state already exists.
+   *
+   * @param event The event to process.
+   * @param options Options for processing the event.
+   * @returns The projection if the event was processed, `null` if it was skipped because a more recent state already
+   *   exists.
+   */
+  async processOrSkipEvent(
+    event: E,
+    options: VersionedEventProcessingOptions<RWT, P> = {},
+  ): Promise<P | null> {
+    try {
+      return await this.processEvent(event, options);
+    } catch (error) {
+      if (error instanceof OldEntityVersionError) {
+        return null;
+      }
+
+      throw error;
+    }
+  }
 }

--- a/src/versioned-entity/index.ts
+++ b/src/versioned-entity/index.ts
@@ -1,8 +1,3 @@
-export { VersionedEventProcessor } from './event-processor.js';
-export type { VersionedProjectionOptions } from './event-processor.js';
-export { VersionedEntityManager } from './manager.js';
-export type {
-  VersionedEntityOperationOptions,
-  VersionedEntityUpdateOptions,
-} from './manager.js';
+export * from './event-processor.js';
+export * from './manager.js';
 export * from './versioned-entity.js';

--- a/src/versioned-entity/manager.spec.ts
+++ b/src/versioned-entity/manager.spec.ts
@@ -632,7 +632,11 @@ describe('VersionedEntityManager', () => {
     });
 
     it('should fail creation if the entity already exists', async () => {
-      const existingEntity = new MySimpleEntity({ id: 'abc' });
+      const existingEntity = new MySimpleEntity({
+        id: 'abc',
+        // Although there is a `deletedAt` property, it should not be taken into account when checking for existence.
+        deletedAt: new Date(),
+      } as any);
       mockTransaction.set(existingEntity);
 
       const actualPromise = manager.create('myEntityCreated', {
@@ -646,7 +650,11 @@ describe('VersionedEntityManager', () => {
     });
 
     it('should update the entity', async () => {
-      const existingEntity = new MySimpleEntity({ id: 'abc' });
+      const existingEntity = new MySimpleEntity({
+        id: 'abc',
+        // Same as creation, the `deletedAt` property should not be taken into account.
+        deletedAt: new Date(),
+      } as any);
       mockTransaction.set(existingEntity);
       const validationFn = jest.fn(() => Promise.resolve());
 

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -214,8 +214,11 @@ export class VersionedEntityManager<
 
         transaction.validatePastDateOrFail(existingEntity.updatedAt);
 
-        // This could `null` for a soft-deleted entity, or `undefined` if `deletedAt` is not a property of the entity.
-        if (existingEntity.deletedAt == null) {
+        // This could be `null` for a soft-deleted entity.
+        if (
+          !this.hasDeletionTimestampProperty ||
+          existingEntity.deletedAt === null
+        ) {
           throw new EntityAlreadyExistsError(this.projectionType, entity);
         }
       },
@@ -243,7 +246,11 @@ export class VersionedEntityManager<
           options.existingEntity ??
           (await transaction.get(this.projectionType, entity));
 
-        if (!existingEntity || existingEntity.deletedAt != null) {
+        if (
+          !existingEntity ||
+          (this.hasDeletionTimestampProperty &&
+            existingEntity.deletedAt !== null)
+        ) {
           throw new EntityNotFoundError(this.projectionType, entity);
         }
 

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -17,6 +17,7 @@ import {
   Transaction,
   TransactionRunner,
   type ReadOnlyStateTransaction,
+  type ReadOnlyTransactionOption,
   type TransactionOption,
 } from '../transaction/index.js';
 import type { KeyOfType } from '../typing/index.js';
@@ -329,6 +330,19 @@ export class VersionedEntityManager<
         return event;
       },
     );
+  }
+
+  async get(
+    key: Partial<EventData<E>>,
+    options: ReadOnlyTransactionOption<ROT> = {},
+  ): Promise<EventData<E>> {
+    const entity = await super.get(key, options);
+
+    if (this.hasDeletionTimestampProperty && entity.deletedAt) {
+      throw new EntityNotFoundError(this.projectionType, key);
+    }
+
+    return entity;
   }
 
   /**

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -292,7 +292,14 @@ export class VersionedEntityManager<
   protected async makeProcessAndPublishEvent(
     eventName: EventName<E>,
     entity: EventData<E>,
-    options: VersionedEntityOperationOptions<RWT> = {},
+    options: VersionedEntityOperationOptions<RWT> & {
+      /**
+       * The existing state of the entity for which an event is being created.
+       * If provided, this is passed as the `existingState` to the {@link VersionedEventProcessor} to avoid fetching
+       * the entity from the state again.
+       */
+      existingEntity?: EventData<E> | null;
+    } = {},
   ): Promise<E> {
     return await this.runner.run(
       { transaction: options.transaction },
@@ -316,7 +323,7 @@ export class VersionedEntityManager<
 
         await this.processEvent(event, {
           transaction,
-          skipVersionCheck: true,
+          existingState: options.existingEntity,
         });
 
         return event;
@@ -357,6 +364,7 @@ export class VersionedEntityManager<
         const event = await this.makeProcessAndPublishEvent(eventName, entity, {
           transaction,
           publishOptions: options.publishOptions,
+          existingEntity: null,
         });
 
         return event;
@@ -434,6 +442,7 @@ export class VersionedEntityManager<
         const event = await this.makeProcessAndPublishEvent(eventName, entity, {
           transaction,
           publishOptions: options.publishOptions,
+          existingEntity,
         });
 
         return event;
@@ -484,6 +493,7 @@ export class VersionedEntityManager<
         const event = await this.makeProcessAndPublishEvent(eventName, entity, {
           transaction,
           publishOptions: options.publishOptions,
+          existingEntity,
         });
 
         return event;


### PR DESCRIPTION
- **🐛 Do not check deletedAt when the entity does not have a deletion property**
- **💥 Replace skipVersionCheck option with existingState in the VersionedEventProcessor**
- **✨ Implement VersionedEventProcessor.get**
- **✨ Implement VersionedEntityManager.get**
- **💥 Make VersionedEventProcessor.processEvent throw instead of returning null**
- **✨ Implement the VersionedEventProcessor.processOrSkipEvent convenience method**
- **✨ Support reprocessEqualVersion when processing events for backfilling use cases**
- **✅ Simplify VersionedEventProcessor tests**
- **💥 Allow VersionedEventProcessor.project to return a context with the version property to use**
- **💥 Replace stateKeyForEvent logic with ProjectionContext**
- **✨ Support VersionedEventProcessor.project returning a partial projection and a nullProjection**
- **📝 Update changelog**

### 📝 Description of the PR

<!-- What does this PR do? -->

### 📋 Check list

- [ ] 🧪 Unit tests have been written.
- [ ] 📝 Documentation has been updated.
