### PR TITLE
🔧 Configure the package for publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+@causa:registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@causa/runtime",
   "version": "0.27.2",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
-  "repository": "github:causa-io/runtime-typescript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/causa-io/runtime-typescript.git"
+  },
   "license": "ISC",
   "type": "module",
   "engines": {


### PR DESCRIPTION
### 📝 Description of the PR

This should fix the CI, for which publishing was failing because the `NPM_TOKEN` wasn't used.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~