### PR TITLE
💥 Replace the base `HttpError` class with `makeHttpException` and `throwHttpErrorResponse` utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Replace the base `HttpError` class with `makeHttpException` and `throwHttpErrorResponse` utilities, and remove `HttpError` classes from DTO definitions.
+- Remove exception filters for specific entity errors.
+
 ## v1.0.0-rc.1 (2025-07-09)
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A user's claims can be checked using the `doesUserSatisfyClaimRequirements` func
 
 ### Errors
 
-This package exposes some entity-related errors (e.g. `EntityNotFoundError`) meant to be thrown by logic processing entities. In a NestJS service, those entity errors are caught and converted to HTTP errors.
+This package exposes some entity-related errors (e.g. `EntityNotFoundError`) meant to be thrown by logic processing entities.
 
 Another very useful error is the `RetryableError`. Any business logic can throw this error to indicate that the process that failed is worth retrying. The `RetryableError` can be handled differently depending on the context. For example for an event-processing function, it indicates that the processing of the event should be retried.
 

--- a/src/nestjs/app/create.spec.ts
+++ b/src/nestjs/app/create.spec.ts
@@ -13,8 +13,9 @@ import { IsPhoneNumber } from 'class-validator';
 import { PinoLogger } from 'nestjs-pino';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent.js';
-import { EntityAlreadyExistsError } from '../../errors/index.js';
 import { getLoggedObjects, spyOnLogger } from '../../logging/testing.js';
+import { ConflictErrorDto } from '../errors/errors.dto.js';
+import { throwHttpErrorResponse } from '../errors/http-error.js';
 import { createApp } from './create.js';
 
 class PostTestDto {
@@ -42,7 +43,7 @@ class TestController {
 
   @Get('/conflict')
   async throwAlreadyExist() {
-    throw new EntityAlreadyExistsError({} as any, {});
+    throwHttpErrorResponse(new ConflictErrorDto());
   }
 
   @Post('/')

--- a/src/nestjs/auth/user-claims.guard.ts
+++ b/src/nestjs/auth/user-claims.guard.ts
@@ -8,7 +8,8 @@ import {
   type UserClaimRequirements,
   doesUserSatisfyClaimRequirements,
 } from '../../auth/index.js';
-import { ForbiddenError } from '../errors/index.js';
+import { ForbiddenErrorDto } from '../errors/errors.dto.js';
+import { throwHttpErrorResponse } from '../errors/http-error.js';
 import { USER_CLAIM_REQUIREMENTS_KEY } from './require-user-claims.decorator.js';
 
 /**
@@ -44,7 +45,7 @@ export class UserClaimsGuard implements CanActivate {
       requirements,
     );
     if (!satisfiesRequirements) {
-      throw new ForbiddenError();
+      throwHttpErrorResponse(new ForbiddenErrorDto());
     }
 
     return true;

--- a/src/nestjs/errors/errors.dto.ts
+++ b/src/nestjs/errors/errors.dto.ts
@@ -2,7 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 import { ApiConstantProperty } from '../openapi/index.js';
-import { type ErrorResponse, HttpError } from './http-error.js';
+import type { ErrorResponse } from './http-error.js';
 
 /**
  * The base class for all error DTOs, providing OpenAPI metadata.
@@ -39,15 +39,6 @@ export class NotFoundErrorDto extends ErrorDto {
 }
 
 /**
- * An error mapped to a generic 404 HTTP error.
- */
-export class NotFoundError extends HttpError<NotFoundErrorDto> {
-  constructor(message?: string) {
-    super(new NotFoundErrorDto(message));
-  }
-}
-
-/**
  * The response for a {@link ConflictError}.
  */
 export class ConflictErrorDto extends ErrorDto {
@@ -61,15 +52,6 @@ export class ConflictErrorDto extends ErrorDto {
     readonly message: string = 'The request conflicts with existing resource(s) on the server.',
   ) {
     super();
-  }
-}
-
-/**
- * An error mapped to a generic 409 HTTP error.
- */
-export class ConflictError extends HttpError<ConflictErrorDto> {
-  constructor(message?: string) {
-    super(new ConflictErrorDto(message));
   }
 }
 
@@ -91,16 +73,6 @@ export class IncorrectVersionErrorDto extends ErrorDto {
 }
 
 /**
- * An error mapped to a 409 HTTP error, thrown when the client does not provide the correct version of the resource to
- * modify.
- */
-export class IncorrectVersionError extends HttpError<IncorrectVersionErrorDto> {
-  constructor(message?: string) {
-    super(new IncorrectVersionErrorDto(message));
-  }
-}
-
-/**
  * The response for a {@link InternalServerError}.
  */
 export class InternalServerErrorDto extends ErrorDto {
@@ -118,15 +90,6 @@ export class InternalServerErrorDto extends ErrorDto {
 }
 
 /**
- * An error mapped to a generic 500 HTTP error.
- */
-export class InternalServerError extends HttpError<InternalServerErrorDto> {
-  constructor(message?: string) {
-    super(new InternalServerErrorDto(message));
-  }
-}
-
-/**
  * The response for a {@link BadRequestError}.
  */
 export class BadRequestErrorDto extends ErrorDto {
@@ -138,15 +101,6 @@ export class BadRequestErrorDto extends ErrorDto {
 
   constructor(readonly message: string = 'The request is invalid.') {
     super();
-  }
-}
-
-/**
- * An error mapped to a generic 400 HTTP error.
- */
-export class BadRequestError extends HttpError<BadRequestErrorDto> {
-  constructor(message?: string) {
-    super(new BadRequestErrorDto(message));
   }
 }
 
@@ -175,15 +129,6 @@ export class ValidationErrorDto extends ErrorDto {
 }
 
 /**
- * An error thrown when a request fails validation, mapped to a 400 HTTP error.
- */
-export class ValidationError extends HttpError<ValidationErrorDto> {
-  constructor(message: string, fields: string[]) {
-    super(new ValidationErrorDto(message, fields));
-  }
-}
-
-/**
  * The response for a {@link UnauthenticatedError}.
  */
 export class UnauthenticatedErrorDto extends ErrorDto {
@@ -195,17 +140,6 @@ export class UnauthenticatedErrorDto extends ErrorDto {
 
   constructor(readonly message: string = 'The request must be authenticated.') {
     super();
-  }
-}
-
-/**
- * An error mapped to a generic 401 HTTP error.
- * "Unauthenticated" is closer to the true meaning of the error: no authentication mechanism was provided with the
- * request.
- */
-export class UnauthenticatedError extends HttpError<UnauthenticatedErrorDto> {
-  constructor() {
-    super(new UnauthenticatedErrorDto());
   }
 }
 
@@ -225,15 +159,6 @@ export class ForbiddenErrorDto extends ErrorDto {
 }
 
 /**
- * An error mapped to a generic 403 HTTP error.
- */
-export class ForbiddenError extends HttpError<ForbiddenErrorDto> {
-  constructor() {
-    super(new ForbiddenErrorDto());
-  }
-}
-
-/**
  * The response for a {@link ServiceUnavailableError}.
  */
 export class ServiceUnavailableErrorDto extends ErrorDto {
@@ -247,14 +172,5 @@ export class ServiceUnavailableErrorDto extends ErrorDto {
     readonly message: string = 'The server is currently unable to handle the request.',
   ) {
     super();
-  }
-}
-
-/**
- * An error mapped to a generic 503 HTTP error.
- */
-export class ServiceUnavailableError extends HttpError<ServiceUnavailableErrorDto> {
-  constructor() {
-    super(new ServiceUnavailableErrorDto());
   }
 }

--- a/src/nestjs/errors/exception-filter.module.ts
+++ b/src/nestjs/errors/exception-filter.module.ts
@@ -1,34 +1,12 @@
 import { Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
-import {
-  EntityAlreadyExistsFilter,
-  EntityNotFoundFilter,
-  GlobalFilter,
-  IncorrectEntityVersionFilter,
-} from './exceptions.filter.js';
+import { GlobalFilter } from './exceptions.filter.js';
 
 /**
- * This module exposes exception filters for Causa-defined errors, as well as a global filter meant to catch all
- * unexpected errors and convert them to a generic `InternalServerError`.
+ * This module exposes a global exception filter meant to catch all unexpected errors and convert them to a generic
+ * `InternalServerError`. `RetryableError`s will be converted to a `ServiceUnavailableError`.
  */
 @Module({
-  providers: [
-    {
-      provide: APP_FILTER,
-      useClass: GlobalFilter,
-    },
-    {
-      provide: APP_FILTER,
-      useClass: EntityAlreadyExistsFilter,
-    },
-    {
-      provide: APP_FILTER,
-      useClass: EntityNotFoundFilter,
-    },
-    {
-      provide: APP_FILTER,
-      useClass: IncorrectEntityVersionFilter,
-    },
-  ],
+  providers: [{ provide: APP_FILTER, useClass: GlobalFilter }],
 })
 export class ExceptionFilterModule {}

--- a/src/nestjs/errors/exceptions.filter.ts
+++ b/src/nestjs/errors/exceptions.filter.ts
@@ -5,49 +5,12 @@ import {
   Logger,
 } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
+import { RetryableError } from '../../errors/index.js';
 import {
-  EntityAlreadyExistsError,
-  EntityNotFoundError,
-  IncorrectEntityVersionError,
-  RetryableError,
-} from '../../errors/index.js';
-import {
-  ConflictError,
-  IncorrectVersionError,
-  InternalServerError,
-  NotFoundError,
-  ServiceUnavailableError,
+  InternalServerErrorDto,
+  ServiceUnavailableErrorDto,
 } from './errors.dto.js';
-
-/**
- * A filter that converts {@link EntityNotFoundError}s to {@link NotFoundError}s.
- */
-@Catch(EntityNotFoundError)
-export class EntityNotFoundFilter extends BaseExceptionFilter {
-  catch(_: EntityNotFoundError, host: ArgumentsHost) {
-    super.catch(new NotFoundError(), host);
-  }
-}
-
-/**
- * A filter that converts {@link EntityAlreadyExistsError}s to {@link ConflictError}s.
- */
-@Catch(EntityAlreadyExistsError)
-export class EntityAlreadyExistsFilter extends BaseExceptionFilter {
-  catch(_: EntityAlreadyExistsError, host: ArgumentsHost) {
-    super.catch(new ConflictError(), host);
-  }
-}
-
-/**
- * A filter that converts {@link IncorrectEntityVersionError}s to {@link IncorrectVersionError}s.
- */
-@Catch(IncorrectEntityVersionError)
-export class IncorrectEntityVersionFilter extends BaseExceptionFilter {
-  catch(_: IncorrectEntityVersionError, host: ArgumentsHost) {
-    super.catch(new IncorrectVersionError(), host);
-  }
-}
+import { makeHttpException } from './http-error.js';
 
 /**
  * A filter that forwards {@link HttpException} subclasses (including `HttpError`) to the {@link BaseExceptionFilter},
@@ -67,14 +30,14 @@ export class GlobalFilter extends BaseExceptionFilter {
         exception.statusCode,
       );
     } else if (exception instanceof RetryableError) {
-      converted = new ServiceUnavailableError();
+      converted = makeHttpException(new ServiceUnavailableErrorDto());
 
       const logObject = { error: exception?.stack };
       const message =
         'A retryable error was caught by the global exception filter.';
       GlobalFilter.globalFilterLogger.warn(logObject, message);
     } else {
-      converted = new InternalServerError();
+      converted = makeHttpException(new InternalServerErrorDto());
 
       // All uncaught errors that don't inherit from `HttpException` will be converted to a generic
       // `InternalServerError`. This will disable the behavior in `BaseExceptionFilter.handleUnknownError`.

--- a/src/nestjs/errors/http-error.ts
+++ b/src/nestjs/errors/http-error.ts
@@ -21,16 +21,21 @@ export type ErrorResponse = {
 };
 
 /**
- * An error that will be converted to an HTTP response sent to the client.
- * This should be subclassed by all errors that should be returned to the client.
+ * Creates an {@link HttpException} from the provided {@link ErrorResponse}.
+ *
+ * @param response The {@link ErrorResponse} that will be used as the body of the response.
+ * @returns The {@link HttpException}.
  */
-export class HttpError<T extends ErrorResponse> extends HttpException {
-  /**
-   * Creates a new {@link HttpError}.
-   *
-   * @param response The response to send to the client.
-   */
-  constructor(response: T) {
-    super(response, response.statusCode);
-  }
+export function makeHttpException(response: ErrorResponse): HttpException {
+  return new HttpException(response, response.statusCode);
+}
+
+/**
+ * Throws an {@link HttpException} with the provided {@link ErrorResponse} as its body.
+ * The global exception filter will catch this and convert it to an HTTP response.
+ *
+ * @param response The {@link ErrorResponse} that will be used as the body of the response.
+ */
+export function throwHttpErrorResponse(response: ErrorResponse): never {
+  throw makeHttpException(response);
 }

--- a/src/nestjs/events/base.interceptor.ts
+++ b/src/nestjs/events/base.interceptor.ts
@@ -11,7 +11,8 @@ import { catchError, mergeMap } from 'rxjs/operators';
 import { RetryableError } from '../../errors/index.js';
 import { type EventAttributes, InvalidEventError } from '../../events/index.js';
 import { ValidationError } from '../../validation/index.js';
-import { ServiceUnavailableError } from '../errors/index.js';
+import { ServiceUnavailableErrorDto } from '../errors/errors.dto.js';
+import { makeHttpException } from '../errors/index.js';
 import { Logger } from '../logging/index.js';
 import { EVENT_BODY_TYPE_KEY } from './event-body.decorator.js';
 import type { RequestWithEvent } from './request-with-event.js';
@@ -156,7 +157,11 @@ export abstract class BaseEventHandlerInterceptor implements NestInterceptor {
                 : 'A retryable error was thrown.',
             );
             return timer(error.delay ?? 0).pipe(
-              mergeMap(() => throwError(() => new ServiceUnavailableError())),
+              mergeMap(() =>
+                throwError(() =>
+                  makeHttpException(new ServiceUnavailableErrorDto()),
+                ),
+              ),
             );
           }
 

--- a/src/nestjs/pagination/custom-read-after-type.decorator.ts
+++ b/src/nestjs/pagination/custom-read-after-type.decorator.ts
@@ -1,6 +1,7 @@
 import { plainToInstance, Transform } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ValidationError } from '../errors/index.js';
+import { ValidationErrorDto } from '../errors/errors.dto.js';
+import { throwHttpErrorResponse } from '../errors/http-error.js';
 import { PageQuery } from './query.js';
 
 /**
@@ -35,9 +36,11 @@ function decorateReadAfterPropertyWithClassTransformer(
         const plainValue = JSON.parse(jsonString);
         return plainToInstance(readAfterType, plainValue);
       } catch {
-        throw new ValidationError(`Invalid pagination key '${propertyName}'.`, [
-          propertyName,
-        ]);
+        throwHttpErrorResponse(
+          new ValidationErrorDto(`Invalid pagination key '${propertyName}'.`, [
+            propertyName,
+          ]),
+        );
       }
     },
     { toClassOnly: true },

--- a/src/nestjs/validation/pipe.ts
+++ b/src/nestjs/validation/pipe.ts
@@ -5,7 +5,8 @@ import {
   type ValidationError as ValidatorError,
 } from '@nestjs/common';
 import { validatorOptions } from '../../validation/index.js';
-import { ValidationError } from '../errors/index.js';
+import { ValidationErrorDto } from '../errors/errors.dto.js';
+import { makeHttpException } from '../errors/index.js';
 
 /**
  * Removes all `undefined` properties from the given object recursively.
@@ -59,9 +60,11 @@ export class ValidationPipe extends BaseValidationPipe {
         );
         const fields = flattenedErrors.flatMap((error) => error.property);
 
-        return new ValidationError(
-          messages.map((message) => `- ${message}`).join('\n'),
-          fields,
+        return makeHttpException(
+          new ValidationErrorDto(
+            messages.map((message) => `- ${message}`).join('\n'),
+            fields,
+          ),
         );
       },
     });


### PR DESCRIPTION
### 📝 Description of the PR

This changes the error-handling utilities, by removing the base `HttpError` and its subclasses.
The point is to dissuade developers from throwing HTTP errors from services, and rather convert errors when reaching the controller layer.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.