### PR TITLE
✨ Allow throwing a custom not found error in `VersionedEventProcessor` and `VersionedEntityManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
 
 - Return `null` instead of `undefined` in `[State]Transaction.get`.
 
+Features:
+
+- Define `VersionedEventProcessor.throwNotFoundError` to allow customizing the thrown error.
+
 Fixes:
 
 - Export `tryMap`.

--- a/src/versioned-entity/event-processor.spec.ts
+++ b/src/versioned-entity/event-processor.spec.ts
@@ -459,5 +459,17 @@ describe('VersionedEntityEventProcessor', () => {
       expect(actualProjection).toEqual(expectedEntity);
       expect(processor.runner.runReadWrite).not.toHaveBeenCalled();
     });
+
+    it('should throw a custom error', async () => {
+      jest
+        .spyOn(processor as any, 'throwNotFoundError')
+        .mockImplementationOnce(() => {
+          throw new Error('😢');
+        });
+
+      const actualPromise = processor.get({ id: '123' });
+
+      await expect(actualPromise).rejects.toThrow('😢');
+    });
   });
 });

--- a/src/versioned-entity/event-processor.ts
+++ b/src/versioned-entity/event-processor.ts
@@ -203,6 +203,16 @@ export abstract class VersionedEventProcessor<
   }
 
   /**
+   * Throws the error corresponding to the entity not being found.
+   * By default, this throws an {@link EntityNotFoundError}, but it can be overridden to throw a different error.
+   *
+   * @param key The key of the entity that was not found.
+   */
+  protected throwNotFoundError(key: Partial<P>): never {
+    throw new EntityNotFoundError(this.projectionType, key);
+  }
+
+  /**
    * Retrieves the projection for the given key.
    * If the projection does not exist, an {@link EntityNotFoundError} is thrown.
    *
@@ -219,7 +229,7 @@ export abstract class VersionedEventProcessor<
       async (transaction) => {
         const state = await transaction.get(this.projectionType, key);
         if (!state) {
-          throw new EntityNotFoundError(this.projectionType, key);
+          this.throwNotFoundError(key);
         }
 
         return state;

--- a/src/versioned-entity/manager.spec.ts
+++ b/src/versioned-entity/manager.spec.ts
@@ -145,6 +145,18 @@ describe('VersionedEntityManager', () => {
       });
     });
 
+    it('should throw a custom error', async () => {
+      jest
+        .spyOn(manager as any, 'throwNotFoundError')
+        .mockImplementationOnce(() => {
+          throw new Error('😢');
+        });
+
+      const actualPromise = manager.get({ id: '123' });
+
+      await expect(actualPromise).rejects.toThrow('😢');
+    });
+
     it('should return the entity if it exists', async () => {
       const expectedEntity = new MyEntity({ id: 'abc' });
       mockTransaction.set(expectedEntity);
@@ -293,6 +305,22 @@ describe('VersionedEntityManager', () => {
       await expect(actualPromise).rejects.toThrow(EntityNotFoundError);
       expect(mockTransaction.entities).toEqual({ abc: existingEntity });
       expect(mockTransaction.events).toBeEmpty();
+    });
+
+    it('should throw a custom error', async () => {
+      jest
+        .spyOn(manager as any, 'throwNotFoundError')
+        .mockImplementationOnce(() => {
+          throw new Error('😢');
+        });
+
+      const actualPromise = manager.update(
+        'myEntityUpdated',
+        { id: '123' },
+        { someProperty: '🔖' },
+      );
+
+      await expect(actualPromise).rejects.toThrow('😢');
     });
 
     it('should fail if the version timestamps do not match', async () => {

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -3,7 +3,6 @@ import { plainToInstance } from 'class-transformer';
 import * as uuid from 'uuid';
 import {
   EntityAlreadyExistsError,
-  EntityNotFoundError,
   IncorrectEntityVersionError,
   UnsupportedEntityOperationError,
 } from '../errors/index.js';
@@ -252,7 +251,7 @@ export class VersionedEntityManager<
           (this.hasDeletionTimestampProperty &&
             existingEntity.deletedAt !== null)
         ) {
-          throw new EntityNotFoundError(this.projectionType, entity);
+          this.throwNotFoundError(entity);
         }
 
         if (options.validationFn) {
@@ -339,7 +338,7 @@ export class VersionedEntityManager<
     const entity = await super.get(key, options);
 
     if (this.hasDeletionTimestampProperty && entity.deletedAt) {
-      throw new EntityNotFoundError(this.projectionType, key);
+      this.throwNotFoundError(key);
     }
 
     return entity;


### PR DESCRIPTION
### 📝 Description of the PR

This makes it easier for classes extending `VersionedEventProcessor` and `VersionedEntityManager` to throw a more specific error.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.