### PR TITLE
🐛 Ensure the method name and metadata is preserved when wrapping using `@TryMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Ensure the method name and metadata is preserved when wrapping using `@TryMap`.
+
 ## v1.2.0 (2025-10-01)
 
 Features:


### PR DESCRIPTION
### 📝 Description of the PR

This PR ensures that the `@TryMap` decorator properly preserves both the method name and reflection metadata from the original method when creating the wrapper function. This is particularly important for NestJS applications, where decorators like `@Get()`, `@Post()`, and OpenAPI metadata decorators rely on reflection metadata to function correctly.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.