### PR TITLE
🔖 Prepare v2.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.0-beta.1 (2026-06-10)
+
 Breaking changes:
 
 - Upgrade the minimum Node.js version to `22`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "1.6.3",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "1.6.3",
+      "version": "2.0.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "1.6.3",
+  "version": "2.0.0-beta.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Breaking changes:

- Upgrade the minimum Node.js version to `22`.

Chore:

- Upgrade dependencies.