### PR TITLE
♻️ Replace the uuid package with the native randomUUID function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Chore:
+
+- Remove the `uuid` package in favor of the native `randomUUID` function.
+
 ## v2.0.0-beta.1 (2026-06-10)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "pino": "^10.3.1",
         "raw-body": "^3.0.2",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.2",
-        "uuid": "^14.0.0"
+        "rxjs": "^7.8.2"
       },
       "devDependencies": {
         "@nestjs/testing": "^11.1.26",
@@ -37,7 +36,6 @@
         "@types/node": "^20.19.42",
         "@types/passport-http-bearer": "^1.0.42",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^11.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
@@ -2458,17 +2456,6 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
-      }
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
       }
     },
     "node_modules/@types/validator": {
@@ -8302,19 +8289,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "pino": "^10.3.1",
     "raw-body": "^3.0.2",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2",
-    "uuid": "^14.0.0"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@nestjs/testing": "^11.1.26",
@@ -63,7 +62,6 @@
     "@types/node": "^20.19.42",
     "@types/passport-http-bearer": "^1.0.42",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^11.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",

--- a/src/lock/manager.spec.ts
+++ b/src/lock/manager.spec.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 import 'jest-extended';
-import * as uuid from 'uuid';
+import { randomUUID } from 'node:crypto';
 import {
   MockRunner,
   type MockTransaction,
@@ -36,10 +36,10 @@ describe('LockManager', () => {
 
   describe('acquire', () => {
     it('should fail to acquire the lock when it is not expired', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('3000-01-01'),
         someCustomData: '📦',
       });
@@ -53,10 +53,10 @@ describe('LockManager', () => {
     });
 
     it('should acquire an existing but expired lock', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('2000-01-01'),
         someCustomData: null,
       });
@@ -75,7 +75,7 @@ describe('LockManager', () => {
     });
 
     it('should acquire the lock', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
       const returnedLock = await manager.acquire(id);
 
@@ -90,7 +90,7 @@ describe('LockManager', () => {
     });
 
     it('should store the passed extra data', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
       const returnedLock = await manager.acquire(id, {
         extraData: { someCustomData: '💡' },
@@ -107,10 +107,10 @@ describe('LockManager', () => {
     });
 
     it('should fail to acquire the lock if extra validation fails', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('2021-01-01'),
         someCustomData: 'nope',
       });
@@ -130,7 +130,7 @@ describe('LockManager', () => {
     });
 
     it('should set a custom expiration delay', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
       const returnedLock = await manager.acquire(id, {
         expirationDelay: 2000,
@@ -147,7 +147,7 @@ describe('LockManager', () => {
     });
 
     it('should acquire an existing lock with null values', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
         lock: null,
@@ -170,7 +170,7 @@ describe('LockManager', () => {
 
     it('should run in a transaction', async () => {
       jest.spyOn(runner, 'runReadWrite');
-      const id = uuid.v4();
+      const id = randomUUID();
 
       await manager.acquire(id, { transaction: mockTransaction });
 
@@ -178,10 +178,10 @@ describe('LockManager', () => {
     });
 
     it('should reuse an existing expired lock when useExisting is true', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('2000-01-01'),
         someCustomData: '📦',
       });
@@ -203,7 +203,7 @@ describe('LockManager', () => {
     });
 
     it('should create a new lock when useExisting is true but no lock exists', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
       const returnedLock = await manager.acquire(id, {
         useExisting: true,
@@ -221,10 +221,10 @@ describe('LockManager', () => {
     });
 
     it('should fail to acquire when useExisting is true and lock is not expired', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('3000-01-01'),
         someCustomData: '📦',
       });
@@ -240,10 +240,10 @@ describe('LockManager', () => {
 
   describe('checkNotAcquiredOrFail', () => {
     it('should throw when the lock is not expired', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('3000-01-01'),
         someCustomData: '📦',
       });
@@ -255,10 +255,10 @@ describe('LockManager', () => {
     });
 
     it('should not throw for an existing but expired lock', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('2000-01-01'),
         someCustomData: null,
       });
@@ -270,7 +270,7 @@ describe('LockManager', () => {
     });
 
     it('should not throw when the lock does not exist', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
       const actualPromise = manager.checkNotAcquiredOrFail(id, mockTransaction);
 
@@ -278,10 +278,10 @@ describe('LockManager', () => {
     });
 
     it('should fail if extra validation fails', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
       const existingLock = new MyLock({
         id,
-        lock: uuid.v4(),
+        lock: randomUUID(),
         expiresAt: new Date('2021-01-01'),
         someCustomData: 'nope',
       });
@@ -305,9 +305,9 @@ describe('LockManager', () => {
 
   describe('release', () => {
     it('should fail to release a lock that does not exist', async () => {
-      const id = uuid.v4();
+      const id = randomUUID();
 
-      const releaseLockPromise = manager.release({ id, lock: uuid.v4() });
+      const releaseLockPromise = manager.release({ id, lock: randomUUID() });
 
       await expect(releaseLockPromise).rejects.toThrow(LockReleaseError);
       await expect(releaseLockPromise).rejects.toThrow(
@@ -318,8 +318,8 @@ describe('LockManager', () => {
     });
 
     it('should fail to release a lock that does not match', async () => {
-      const id = uuid.v4();
-      const lock = uuid.v4();
+      const id = randomUUID();
+      const lock = randomUUID();
       const existingLock = new MyLock({
         id,
         lock,
@@ -329,7 +329,7 @@ describe('LockManager', () => {
       await mockTransaction.set(existingLock);
 
       const releaseLockPromise = manager.release(
-        { id, lock: uuid.v4() },
+        { id, lock: randomUUID() },
         { delete: false },
       );
 
@@ -342,8 +342,8 @@ describe('LockManager', () => {
     });
 
     it('should delete the lock', async () => {
-      const id = uuid.v4();
-      const lock = uuid.v4();
+      const id = randomUUID();
+      const lock = randomUUID();
       const existingLock = new MyLock({
         id,
         lock,
@@ -358,8 +358,8 @@ describe('LockManager', () => {
     });
 
     it('should set the lock to null instead of deleting it', async () => {
-      const id = uuid.v4();
-      const lock = uuid.v4();
+      const id = randomUUID();
+      const lock = randomUUID();
       const existingLock = new MyLock({
         id,
         lock,
@@ -379,8 +379,8 @@ describe('LockManager', () => {
     });
 
     it('should set the lock to null and write extra data', async () => {
-      const id = uuid.v4();
-      const lock = uuid.v4();
+      const id = randomUUID();
+      const lock = randomUUID();
       const existingLock = new MyLock({
         id,
         lock,
@@ -405,8 +405,8 @@ describe('LockManager', () => {
 
     it('should run in a transaction', async () => {
       jest.spyOn(runner, 'runReadWrite');
-      const id = uuid.v4();
-      const lock = uuid.v4();
+      const id = randomUUID();
+      const lock = randomUUID();
       const existingLock = new MyLock({
         id,
         lock,

--- a/src/lock/manager.ts
+++ b/src/lock/manager.ts
@@ -1,6 +1,6 @@
 import type { Type } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import * as uuid from 'uuid';
+import { randomUUID } from 'node:crypto';
 import {
   Transaction,
   TransactionRunner,
@@ -136,7 +136,7 @@ export class LockManager<T extends Transaction, E extends LockEntity> {
             ? existingLock
             : options.extraData),
           id,
-          lock: uuid.v4(),
+          lock: randomUUID(),
           expiresAt: new Date(
             transaction.timestamp.getTime() + expirationDelay,
           ),

--- a/src/nestjs/validation/uri.dto.spec.ts
+++ b/src/nestjs/validation/uri.dto.spec.ts
@@ -1,12 +1,12 @@
 import 'jest-extended';
-import * as uuid from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { ValidationError, parseObject } from '../../validation/index.js';
 import { IdParams, VersionedMutationQuery } from './uri.dto.js';
 
 describe('URI DTOs', () => {
   describe('IdParams', () => {
     it('should validate a correct UUID', async () => {
-      const actualPromise = parseObject(IdParams, { id: uuid.v4() });
+      const actualPromise = parseObject(IdParams, { id: randomUUID() });
 
       await expect(actualPromise).toResolve();
     });

--- a/src/transaction/outbox/event-transaction.spec.ts
+++ b/src/transaction/outbox/event-transaction.spec.ts
@@ -1,4 +1,3 @@
-import * as uuid from 'uuid';
 import { OutboxEventTransaction } from './event-transaction.js';
 import { MockPublisher } from './utils.test.js';
 
@@ -30,7 +29,9 @@ describe('OutboxEventTransaction', () => {
           id: expect.any(String),
         },
       ]);
-      expect(uuid.version(transaction.events[0].id)).toBe(4);
+      expect(transaction.events[0].id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
     });
 
     it('should override transaction-wide attributes', async () => {
@@ -48,7 +49,9 @@ describe('OutboxEventTransaction', () => {
           id: expect.any(String),
         },
       ]);
-      expect(uuid.version(transaction.events[0].id)).toBe(4);
+      expect(transaction.events[0].id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
     });
   });
 });

--- a/src/transaction/outbox/event-transaction.ts
+++ b/src/transaction/outbox/event-transaction.ts
@@ -1,4 +1,4 @@
-import * as uuid from 'uuid';
+import { randomUUID } from 'node:crypto';
 import type { EventPublisher, PublishOptions } from '../../events/index.js';
 import type {
   EventTransaction,
@@ -55,7 +55,7 @@ export class OutboxEventTransaction implements EventTransaction {
     });
 
     const staged: StagedOutboxEvent = {
-      id: uuid.v4(),
+      id: randomUUID(),
       topic: prepared.topic,
       data: prepared.data,
       attributes: prepared.attributes ?? {},

--- a/src/versioned-entity/manager.ts
+++ b/src/versioned-entity/manager.ts
@@ -1,6 +1,6 @@
 import type { Type } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import * as uuid from 'uuid';
+import { randomUUID } from 'node:crypto';
 import {
   EntityAlreadyExistsError,
   IncorrectEntityVersionError,
@@ -187,7 +187,7 @@ export class VersionedEntityManager<
    * @returns A unique ID for an event.
    */
   protected generateEventId(): string {
-    return uuid.v4();
+    return randomUUID();
   }
 
   /**


### PR DESCRIPTION
### 📝 Description of the PR

This removes the `uuid` dependency (and `@types/uuid`) in favor of the native `randomUUID` function from `node:crypto`, which provides the same UUID v4 generation without an external package.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.