### PR TITLE
🔖 Prepare v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.0 (2026-06-12)
+
 Chore:
 
 - Remove the `uuid` package in favor of the native `randomUUID` function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Chore:

- Remove the `uuid` package in favor of the native `randomUUID` function.