### PR TITLE
🔖 Prepare v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.1 (2026-07-29)
+
 Fixes:
 
 - Make the `AppFixture` start the application's HTTP server on the loopback address during initialization, rather than letting `supertest` bind it to the IPv6 wildcard address for each request. This avoids requests being routed to an unrelated process listening on `127.0.0.1` with the same port.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Make the `AppFixture` start the application's HTTP server on the loopback address during initialization, rather than letting `supertest` bind it to the IPv6 wildcard address for each request. This avoids requests being routed to an unrelated process listening on `127.0.0.1` with the same port.