### PR TITLE
🔖 Prepare v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.2 (2026-07-31)
+
 Fixes:
 
 - Make the `AppFixture` release the resources it has allocated when its initialization fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Make the `AppFixture` release the resources it has allocated when its initialization fails.