### PR TITLE
✨ Expose validation error fields and add error mapping utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Features:
+
+- Expose the `fields` property on the `ValidationError`, listing the path to each property that failed validation.
+- Add the `validationErrorAsDto` utility, mapping a `ValidationError` (or a subclass of it) to a `ValidationErrorDto`.
+- Add the `ForbiddenError`, meant to be thrown by authorization logic, along with the `forbiddenErrorAsDto` utility mapping it to a `ForbiddenErrorDto`.
+
 ## v2.0.2 (2026-07-31)
 
 Fixes:

--- a/causa.yaml
+++ b/causa.yaml
@@ -17,7 +17,7 @@ project:
 javascript:
   dependencies:
     check:
-      allowlist: [GHSA-mh99-v99m-4gvg, GHSA-pm4m-ph32-ghv5]
+      allowlist: [GHSA-pm4m-ph32-ghv5]
     update:
       packageTargets:
         # The following types should be manually updated to the next major version when the corresponding tool / package

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@nestjs/testing": "^11.1.28",
-        "@swc/core": "^1.15.46",
+        "@swc/core": "^1.15.47",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/express": "^5.0.6",
@@ -109,14 +109,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -239,13 +239,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -509,18 +509,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1394,22 +1394,25 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@nestjs/cache-manager": {
@@ -1780,9 +1783,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.46.tgz",
-      "integrity": "sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+      "integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1798,18 +1801,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.46",
-        "@swc/core-darwin-x64": "1.15.46",
-        "@swc/core-linux-arm-gnueabihf": "1.15.46",
-        "@swc/core-linux-arm64-gnu": "1.15.46",
-        "@swc/core-linux-arm64-musl": "1.15.46",
-        "@swc/core-linux-ppc64-gnu": "1.15.46",
-        "@swc/core-linux-s390x-gnu": "1.15.46",
-        "@swc/core-linux-x64-gnu": "1.15.46",
-        "@swc/core-linux-x64-musl": "1.15.46",
-        "@swc/core-win32-arm64-msvc": "1.15.46",
-        "@swc/core-win32-ia32-msvc": "1.15.46",
-        "@swc/core-win32-x64-msvc": "1.15.46"
+        "@swc/core-darwin-arm64": "1.15.47",
+        "@swc/core-darwin-x64": "1.15.47",
+        "@swc/core-linux-arm-gnueabihf": "1.15.47",
+        "@swc/core-linux-arm64-gnu": "1.15.47",
+        "@swc/core-linux-arm64-musl": "1.15.47",
+        "@swc/core-linux-ppc64-gnu": "1.15.47",
+        "@swc/core-linux-s390x-gnu": "1.15.47",
+        "@swc/core-linux-x64-gnu": "1.15.47",
+        "@swc/core-linux-x64-musl": "1.15.47",
+        "@swc/core-win32-arm64-msvc": "1.15.47",
+        "@swc/core-win32-ia32-msvc": "1.15.47",
+        "@swc/core-win32-x64-msvc": "1.15.47"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -1821,9 +1824,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.46.tgz",
-      "integrity": "sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
       "cpu": [
         "arm64"
       ],
@@ -1838,9 +1841,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.46.tgz",
-      "integrity": "sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
       "cpu": [
         "x64"
       ],
@@ -1855,9 +1858,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.46.tgz",
-      "integrity": "sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
       "cpu": [
         "arm"
       ],
@@ -1872,9 +1875,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.46.tgz",
-      "integrity": "sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
       "cpu": [
         "arm64"
       ],
@@ -1892,9 +1895,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.46.tgz",
-      "integrity": "sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
       "cpu": [
         "arm64"
       ],
@@ -1912,9 +1915,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.46.tgz",
-      "integrity": "sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1932,9 +1935,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.46.tgz",
-      "integrity": "sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
       "cpu": [
         "s390x"
       ],
@@ -1952,9 +1955,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.46.tgz",
-      "integrity": "sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
       "cpu": [
         "x64"
       ],
@@ -1972,9 +1975,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.46.tgz",
-      "integrity": "sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
       "cpu": [
         "x64"
       ],
@@ -1992,9 +1995,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.46.tgz",
-      "integrity": "sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
       "cpu": [
         "arm64"
       ],
@@ -2009,9 +2012,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.46.tgz",
-      "integrity": "sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
       "cpu": [
         "ia32"
       ],
@@ -2026,9 +2029,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.46",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.46.tgz",
-      "integrity": "sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
       "cpu": [
         "x64"
       ],
@@ -2068,9 +2071,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
-      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2248,9 +2251,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3088,9 +3091,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3365,9 +3368,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
-      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "version": "2.11.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
+      "integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3452,9 +3455,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4082,9 +4085,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4701,9 +4704,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -4953,9 +4956,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6137,9 +6140,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
-      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.10.tgz",
+      "integrity": "sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -6339,13 +6342,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7057,9 +7060,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",
@@ -7961,9 +7964,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.1.28",
-    "@swc/core": "^1.15.46",
+    "@swc/core": "^1.15.47",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/express": "^5.0.6",

--- a/src/errors/authorization.ts
+++ b/src/errors/authorization.ts
@@ -1,0 +1,19 @@
+/**
+ * An error thrown when an operation is not allowed in the current context, e.g. for the authenticated user.
+ * Although it usually translates to a "forbidden" HTTP response, this error is not tied to HTTP, such that it can be
+ * thrown by authorization logic running in any context.
+ */
+export class ForbiddenError extends Error {
+  /**
+   * Creates a new {@link ForbiddenError}.
+   *
+   * @param message The error message.
+   * @param options Additional options for the error.
+   */
+  constructor(
+    message: string = 'The operation is not allowed.',
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,4 @@
+export * from './authorization.js';
 export * from './entity.js';
 export * from './map.js';
 export * from './processing.js';

--- a/src/nestjs/errors/try-map.spec.ts
+++ b/src/nestjs/errors/try-map.spec.ts
@@ -1,9 +1,12 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { tryMap } from '../../errors/map.js';
+import { ValidationError } from '../../validation/index.js';
 import { ErrorDto } from './errors.dto.js';
-import { toDto, toDtoType } from './try-map.js';
+import { toDto, toDtoType, validationErrorAsDto } from './try-map.js';
 
 class MyError extends Error {}
+
+class MyValidationError extends ValidationError {}
 
 class MyDto extends ErrorDto {
   readonly statusCode = HttpStatus.BAD_REQUEST;
@@ -54,5 +57,51 @@ describe('toDtoType', () => {
         message: '🤷',
       }),
     });
+  });
+});
+
+describe('validationErrorAsDto', () => {
+  it('should catch the error and format the validation messages', async () => {
+    const actualPromise = tryMap(async () => {
+      throw new ValidationError(
+        ['stringProperty must be a string', 'id must be a UUID'],
+        ['stringProperty', 'child.id'],
+      );
+    }, validationErrorAsDto());
+
+    await expect(actualPromise).rejects.toThrow(HttpException);
+    await expect(actualPromise).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+      response: {
+        statusCode: HttpStatus.BAD_REQUEST,
+        errorCode: 'invalidInput',
+        message: '- stringProperty must be a string\n- id must be a UUID',
+        fields: ['stringProperty', 'child.id'],
+      },
+    });
+  });
+
+  it('should catch an error of the given narrower type', async () => {
+    const actualPromise = tryMap(async () => {
+      throw new MyValidationError(['💥'], ['someProperty']);
+    }, validationErrorAsDto(MyValidationError));
+
+    await expect(actualPromise).rejects.toThrow(HttpException);
+    await expect(actualPromise).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+      response: {
+        errorCode: 'invalidInput',
+        message: '- 💥',
+        fields: ['someProperty'],
+      },
+    });
+  });
+
+  it('should not catch an error that is not of the given narrower type', async () => {
+    const actualPromise = tryMap(async () => {
+      throw new ValidationError(['💥']);
+    }, validationErrorAsDto(MyValidationError));
+
+    await expect(actualPromise).rejects.toThrow(ValidationError);
   });
 });

--- a/src/nestjs/errors/try-map.ts
+++ b/src/nestjs/errors/try-map.ts
@@ -1,10 +1,12 @@
 import type { Type } from '@nestjs/common';
 import {
+  ForbiddenError,
   IncorrectEntityVersionError,
   type ErrorCase,
 } from '../../errors/index.js';
 import { ValidationError } from '../../validation/index.js';
 import {
+  ForbiddenErrorDto,
   IncorrectVersionErrorDto,
   ValidationErrorDto,
   type ErrorDto,
@@ -49,6 +51,12 @@ export const incorrectEntityVersionErrorAsDto = toDtoType(
   IncorrectEntityVersionError,
   IncorrectVersionErrorDto,
 );
+
+/**
+ * Maps a {@link ForbiddenError} to a {@link ForbiddenErrorDto}.
+ * The message of the error is not returned to the caller.
+ */
+export const forbiddenErrorAsDto = toDtoType(ForbiddenError, ForbiddenErrorDto);
 
 /**
  * Returns an {@link ErrorCase} that maps a {@link ValidationError} to a {@link ValidationErrorDto}.

--- a/src/nestjs/errors/try-map.ts
+++ b/src/nestjs/errors/try-map.ts
@@ -3,7 +3,12 @@ import {
   IncorrectEntityVersionError,
   type ErrorCase,
 } from '../../errors/index.js';
-import { IncorrectVersionErrorDto, type ErrorDto } from './errors.dto.js';
+import { ValidationError } from '../../validation/index.js';
+import {
+  IncorrectVersionErrorDto,
+  ValidationErrorDto,
+  type ErrorDto,
+} from './errors.dto.js';
 import { makeHttpException } from './http-error.js';
 
 /**
@@ -44,3 +49,24 @@ export const incorrectEntityVersionErrorAsDto = toDtoType(
   IncorrectEntityVersionError,
   IncorrectVersionErrorDto,
 );
+
+/**
+ * Returns an {@link ErrorCase} that maps a {@link ValidationError} to a {@link ValidationErrorDto}.
+ * The {@link ValidationError.validationMessages} are formatted as a bullet list.
+ *
+ * @param type The type of the error to match, which can be narrower than the base {@link ValidationError}.
+ *   Defaults to the {@link ValidationError} itself.
+ * @returns The {@link ErrorCase}.
+ */
+export function validationErrorAsDto(
+  type: Type<ValidationError> = ValidationError,
+): ErrorCase<never, ValidationError> {
+  return toDto(
+    type,
+    (error) =>
+      new ValidationErrorDto(
+        error.validationMessages.map((message) => `- ${message}`).join('\n'),
+        error.fields,
+      ),
+  );
+}

--- a/src/nestjs/errors/try-map.ts
+++ b/src/nestjs/errors/try-map.ts
@@ -1,6 +1,9 @@
 import type { Type } from '@nestjs/common';
-import type { ErrorCase } from '../../errors/index.js';
-import type { ErrorDto } from './errors.dto.js';
+import {
+  IncorrectEntityVersionError,
+  type ErrorCase,
+} from '../../errors/index.js';
+import { IncorrectVersionErrorDto, type ErrorDto } from './errors.dto.js';
 import { makeHttpException } from './http-error.js';
 
 /**
@@ -33,3 +36,11 @@ export function toDtoType<E>(
     throw: () => makeHttpException(new dtoType()),
   };
 }
+
+/**
+ * Maps an {@link IncorrectEntityVersionError} to an {@link IncorrectVersionErrorDto}.
+ */
+export const incorrectEntityVersionErrorAsDto = toDtoType(
+  IncorrectEntityVersionError,
+  IncorrectVersionErrorDto,
+);

--- a/src/validation/errors.ts
+++ b/src/validation/errors.ts
@@ -6,8 +6,13 @@ export class ValidationError extends Error {
    * Creates a new {@link ValidationError}.
    *
    * @param validationMessages The messages describing why the validation failed.
+   * @param fields The paths to the properties that failed validation, e.g. `items.0.name`.
+   *   This is usually expected to be deduplicated. It is empty when the validation failed for the payload as a whole.
    */
-  constructor(readonly validationMessages: string[]) {
+  constructor(
+    readonly validationMessages: string[],
+    readonly fields: string[] = [],
+  ) {
     super('One or more errors occurred during the validation of the object.');
   }
 }

--- a/src/validation/parser.spec.ts
+++ b/src/validation/parser.spec.ts
@@ -1,5 +1,6 @@
-import { IsBoolean, IsString } from 'class-validator';
+import { IsBoolean, IsString, MaxLength } from 'class-validator';
 import 'jest-extended';
+import { ValidateNestedType } from './decorators/index.js';
 import { ValidationError } from './errors.js';
 import { parseObject, validateObject } from './parser.js';
 
@@ -13,6 +14,28 @@ class MyObject {
 
   @IsBoolean()
   booleanProperty!: boolean;
+}
+
+class MyObjectWithSeveralConstraints {
+  constructor(data: MyObjectWithSeveralConstraints) {
+    Object.assign(this, data);
+  }
+
+  @IsString()
+  @MaxLength(3)
+  stringProperty!: string;
+}
+
+class MyParentObject {
+  constructor(data: MyParentObject) {
+    Object.assign(this, data);
+  }
+
+  @ValidateNestedType(() => MyObject)
+  child!: MyObject;
+
+  @ValidateNestedType(() => MyObject)
+  children!: MyObject[];
 }
 
 describe('parser', () => {
@@ -39,14 +62,16 @@ describe('parser', () => {
 
       await expect(actualPromise).rejects.toThrow(ValidationError);
       await expect(actualPromise).rejects.toMatchObject({
-        validationMessages: expect.toSatisfy((messages: string[]) => {
-          expect(messages.sort()).toEqual([
-            'booleanProperty must be a boolean value',
-            'property unknownProperty should not exist',
-            'stringProperty must be a string',
-          ]);
-          return true;
-        }),
+        validationMessages: expect.toIncludeSameMembers([
+          'booleanProperty must be a boolean value',
+          'property unknownProperty should not exist',
+          'stringProperty must be a string',
+        ]),
+        fields: expect.toIncludeSameMembers([
+          'booleanProperty',
+          'stringProperty',
+          'unknownProperty',
+        ]),
       });
     });
 
@@ -59,6 +84,7 @@ describe('parser', () => {
           expect(messages).toEqual(['input must be an object']);
           return true;
         }),
+        fields: [],
       });
     });
 
@@ -71,6 +97,7 @@ describe('parser', () => {
           expect(messages).toEqual(['input must be an object']);
           return true;
         }),
+        fields: [],
       });
     });
 
@@ -87,6 +114,55 @@ describe('parser', () => {
       });
 
       await expect(actualPromise).resolves.toBeUndefined();
+    });
+
+    it('should deduplicate the fields that failed validation', async () => {
+      const obj = new MyObjectWithSeveralConstraints({
+        stringProperty: 1234 as any,
+      });
+
+      const actualPromise = validateObject(obj);
+
+      await expect(actualPromise).rejects.toMatchObject({
+        validationMessages: expect.toIncludeSameMembers([
+          'stringProperty must be a string',
+          'stringProperty must be shorter than or equal to 3 characters',
+        ]),
+        fields: ['stringProperty'],
+      });
+    });
+
+    it('should reference the paths to the nested fields that failed validation', async () => {
+      const obj = new MyParentObject({
+        child: new MyObject({
+          stringProperty: '✅',
+          booleanProperty: '❌' as any,
+        }),
+        children: [
+          new MyObject({ stringProperty: '✅', booleanProperty: true }),
+          new MyObject({ stringProperty: 1234 as any, booleanProperty: true }),
+        ],
+      });
+
+      const actualPromise = validateObject(obj);
+
+      await expect(actualPromise).rejects.toMatchObject({
+        fields: expect.toIncludeSameMembers([
+          'child.booleanProperty',
+          'children.1.stringProperty',
+        ]),
+      });
+    });
+
+    it('should not reference any field when the input has no validation metadata', async () => {
+      const actualPromise = validateObject({ someProperty: '👋' });
+
+      await expect(actualPromise).rejects.toMatchObject({
+        validationMessages: [
+          'an unknown value was passed to the validate function',
+        ],
+        fields: [],
+      });
     });
   });
 
@@ -117,14 +193,16 @@ describe('parser', () => {
 
       await expect(actualPromise).rejects.toThrow(ValidationError);
       await expect(actualPromise).rejects.toMatchObject({
-        validationMessages: expect.toSatisfy((messages: string[]) => {
-          expect(messages.sort()).toEqual([
-            'booleanProperty must be a boolean value',
-            'property unknownProperty should not exist',
-            'stringProperty must be a string',
-          ]);
-          return true;
-        }),
+        validationMessages: expect.toIncludeSameMembers([
+          'booleanProperty must be a boolean value',
+          'property unknownProperty should not exist',
+          'stringProperty must be a string',
+        ]),
+        fields: expect.toIncludeSameMembers([
+          'booleanProperty',
+          'stringProperty',
+          'unknownProperty',
+        ]),
       });
     });
 
@@ -137,6 +215,7 @@ describe('parser', () => {
           expect(messages).toEqual(['payload must be a plain object']);
           return true;
         }),
+        fields: [],
       });
     });
 

--- a/src/validation/parser.ts
+++ b/src/validation/parser.ts
@@ -10,16 +10,46 @@ import { validatorOptions } from './configuration.js';
 import { ValidationError } from './errors.js';
 
 /**
- * Flattens all the validation error messages contained in the given errors and their children.
+ * A single validation failure, referencing the path to the property that failed validation.
+ */
+type ValidationFailure = {
+  /**
+   * The path to the property that failed validation, e.g. `items.0.name`.
+   * This is an empty string when the failure applies to the validated payload as a whole.
+   */
+  field: string;
+
+  /**
+   * The message describing why the validation failed.
+   */
+  message: string;
+};
+
+/**
+ * Flattens all the validation failures contained in the given errors and their children.
  *
  * @param errors The errors returned by `class-validator`'s {@link validate}.
- * @returns The error messages.
+ * @param parentPath The path to the property holding the given errors, if any.
+ * @returns The validation failures.
  */
-function getErrorMessages(errors: ClassValidationError[]): string[] {
-  return errors.flatMap((error) => [
-    ...Object.values(error.constraints ?? {}),
-    ...getErrorMessages(error.children ?? []),
-  ]);
+function getFailures(
+  errors: ClassValidationError[],
+  parentPath = '',
+): ValidationFailure[] {
+  return errors.flatMap((error) => {
+    // Although it is not typed as such, `property` is `undefined` for the error returned when `forbidUnknownValues` is
+    // enabled and the validated object has no metadata at all.
+    const property = error.property ?? '';
+    const field = parentPath ? `${parentPath}.${property}` : property;
+
+    return [
+      ...Object.values(error.constraints ?? {}).map((message) => ({
+        field,
+        message,
+      })),
+      ...getFailures(error.children ?? [], field),
+    ];
+  });
 }
 
 /**
@@ -41,8 +71,11 @@ export async function validateObject(
   const errors = await validate(obj, { ...validatorOptions, ...options });
 
   if (errors.length > 0) {
-    const validationMessages = getErrorMessages(errors);
-    throw new ValidationError(validationMessages);
+    const failures = getFailures(errors);
+    throw new ValidationError(
+      failures.map(({ message }) => message),
+      [...new Set(failures.map(({ field }) => field).filter((f) => f))],
+    );
   }
 }
 


### PR DESCRIPTION
### 📝 Description of the PR

Adds a `fields` property to the `ValidationError`, listing the path to each property that failed validation. Nested objects and arrays are referenced using their full path, e.g. `child.id` or `items.0.name`. The property is populated by the `validateObject` and `parseObject` utilities, and is empty when the validation failed for the payload as a whole.

Several utilities mapping business errors to their `ErrorDto` counterpart are also introduced, meant to be used with the `tryMap` utility and the `@TryMap` decorator: `incorrectEntityVersionErrorAsDto`, `validationErrorAsDto`, and `forbiddenErrorAsDto`. `validationErrorAsDto` formats the validation messages as a bullet list and returns the failing fields to the caller. It optionally accepts an error type, such that a subclass of the `ValidationError` can be matched instead of the base error.

The `forbiddenErrorAsDto` utility maps the new `ForbiddenError`, a business-level error meant to be thrown by authorization logic. Because such logic is usually, but not always, used in an HTTP context, the error itself is defined independently of NestJS. Its message is not returned to the caller, such that it can freely describe why the operation was denied.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
