### PR TITLE
🔖 Prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.1.0 (2026-08-06)
+
 Features:
 
 - Expose the `fields` property on the `ValidationError`, listing the path to each property that failed validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "The package exposing the runtime SDK for Causa, focusing on service containers and event-based processing.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Expose the `fields` property on the `ValidationError`, listing the path to each property that failed validation.
- Add the `validationErrorAsDto` utility, mapping a `ValidationError` (or a subclass of it) to a `ValidationErrorDto`.
- Add the `ForbiddenError`, meant to be thrown by authorization logic, along with the `forbiddenErrorAsDto` utility mapping it to a `ForbiddenErrorDto`.