### PR TITLE
🐛 Fix import cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Fix import cycles.
+
 ## v2.1.0 (2026-08-06)
 
 Features:

--- a/src/nestjs/errors/errors.dto.ts
+++ b/src/nestjs/errors/errors.dto.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
-import { ApiConstantProperty } from '../openapi/index.js';
+import { ApiConstantProperty } from '../openapi/api-constant-property.decorator.js';
 import type { ErrorResponse } from './http-error.js';
 
 /**

--- a/src/nestjs/healthcheck/endpoint.ts
+++ b/src/nestjs/healthcheck/endpoint.ts
@@ -1,0 +1,5 @@
+/**
+ * The name of the endpoint responding to health checks.
+ * The service should respond to this endpoint with a 200 status code if it is healthy.
+ */
+export const HEALTHCHECK_ENDPOINT = 'health';

--- a/src/nestjs/healthcheck/index.ts
+++ b/src/nestjs/healthcheck/index.ts
@@ -1,10 +1,5 @@
-/**
- * The name of the endpoint responding to health checks.
- * The service should respond to this endpoint with a 200 status code if it is healthy.
- */
-export const HEALTHCHECK_ENDPOINT = 'health';
-
 export { BaseHealthIndicatorService } from './base-health-indicator.service.js';
+export { HEALTHCHECK_ENDPOINT } from './endpoint.js';
 export type { HealthChecker } from './checker.js';
 export { HealthCheckModule } from './module.js';
 export * from './terminus.module.js';

--- a/src/nestjs/healthcheck/module.ts
+++ b/src/nestjs/healthcheck/module.ts
@@ -14,7 +14,7 @@ import {
 } from '@nestjs/terminus';
 import { Public } from '../auth/index.js';
 import type { HealthChecker } from './checker.js';
-import { HEALTHCHECK_ENDPOINT } from './index.js';
+import { HEALTHCHECK_ENDPOINT } from './endpoint.js';
 import { terminusModuleWithLogger } from './terminus.module.js';
 
 /**

--- a/src/nestjs/logging/logger.module.ts
+++ b/src/nestjs/logging/logger.module.ts
@@ -2,7 +2,7 @@ import type { DynamicModule, ModuleMetadata } from '@nestjs/common';
 import { LoggerModule as PinoLoggerModule } from 'nestjs-pino';
 import type { Logger } from 'pino';
 import { getDefaultLogger } from '../../logging/index.js';
-import { HEALTHCHECK_ENDPOINT } from '../healthcheck/index.js';
+import { HEALTHCHECK_ENDPOINT } from '../healthcheck/endpoint.js';
 
 /**
  * The NestJS injection token for the {@link LoggerModuleOptions}.

--- a/src/nestjs/openapi/api-error-description.decorator.ts
+++ b/src/nestjs/openapi/api-error-description.decorator.ts
@@ -1,5 +1,5 @@
 import { type Type } from '@nestjs/common';
-import { ErrorDto } from '../errors/index.js';
+import type { ErrorDto } from '../errors/errors.dto.js';
 
 /**
  * The metadata key used to store the API error description.

--- a/src/nestjs/openapi/api-error-responses.decorator.ts
+++ b/src/nestjs/openapi/api-error-responses.decorator.ts
@@ -1,6 +1,6 @@
 import type { Type } from '@nestjs/common';
 import { ApiExtraModels, ApiResponse, refs } from '@nestjs/swagger';
-import { ErrorDto } from '../index.js';
+import type { ErrorDto } from '../errors/errors.dto.js';
 import { getApiErrorDescription } from './api-error-description.decorator.js';
 import { getApiErrorStatusCode } from './api-error-status-code.decorator.js';
 

--- a/src/nestjs/openapi/api-error-status-code.decorator.ts
+++ b/src/nestjs/openapi/api-error-status-code.decorator.ts
@@ -1,5 +1,5 @@
 import { HttpStatus, type Type } from '@nestjs/common';
-import { ErrorDto } from '../errors/index.js';
+import type { ErrorDto } from '../errors/errors.dto.js';
 import { ApiConstantProperty } from './api-constant-property.decorator.js';
 
 /**

--- a/src/nestjs/pagination/custom-read-after-type.decorator.ts
+++ b/src/nestjs/pagination/custom-read-after-type.decorator.ts
@@ -2,7 +2,7 @@ import { plainToInstance, Transform } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ValidationErrorDto } from '../errors/errors.dto.js';
 import { throwHttpErrorResponse } from '../errors/http-error.js';
-import { PageQuery } from './query.js';
+import type { PageQuery } from './query.js';
 
 /**
  * Flag to detect that the {@link PageQuery.readAfter} property has been decorated with {@link CustomReadAfterType}, and


### PR DESCRIPTION
### 📝 Description of the PR

Removes the circular imports present in the `nestjs` sources. Three cycles existed: between the error DTOs and the OpenAPI decorators, within the pagination decorators, and between the healthcheck barrel and its module.

Because the project compiles with `verbatimModuleSyntax`, an `import { X }` statement is emitted verbatim into the JavaScript output even when `X` is only ever used in a type position. Several OpenAPI and pagination decorators imported classes purely for typing, which turned type-only dependencies into real runtime edges. These are now `import type` statements, which are fully erased at compile time. Modules that reached for a sibling barrel re-exporting them now import the specific file they need instead.

The error DTO cycle was the one that could actually fail at runtime: `try-map.ts` builds its error cases at module load time, so entering the cycle from the wrong side left a DTO class in its temporal dead zone. The healthcheck cycle was latent rather than live, as the shared constant is only read inside a static factory method; it would have become a genuine failure as soon as anything used it during module evaluation. To break it, `HEALTHCHECK_ENDPOINT` moved out of the healthcheck barrel into its own module, and the barrel re-exports it.

The public API is unchanged: every symbol is still exported from the same package entry points as before.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~